### PR TITLE
Clarify the pinned assistant chat thread model

### DIFF
--- a/docs/chat-model.md
+++ b/docs/chat-model.md
@@ -127,18 +127,17 @@ Table 5. Browser-facing chat DTOs.
 | Type | Purpose | Evidence |
 | ------ | --------- | ---------- |
 | `SendMessageRequest` | REST request body for `/api/chat/send` | `src/channels/web/types.rs` |
-| `ThreadListResponse` | Browser sidebar model for the pinned assistant thread, regular conversations, and the active-thread selection | `src/channels/web/types.rs`, `src/channels/web/handlers/chat_threads.rs` |
+| `ThreadListResponse` | Browser sidebar model for the pinned assistant thread, regular conversations, and the active thread selection | `src/channels/web/types.rs`, `src/channels/web/handlers/chat_threads.rs` |
 | `HistoryResponse`, `TurnInfo`, `ToolCallInfo` | Browser history and thread view model | `src/channels/web/types.rs`, `src/channels/web/util.rs` |
 | `PendingApprovalInfo` | Re-renders approval state after a thread switch | `src/channels/web/types.rs`, `src/channels/web/handlers/chat_history.rs` |
 | `SseEvent` | Unified live event stream for responses, tool activity, approvals, auth, jobs, and generated images | `src/channels/web/types.rs`, `src/channels/web/mod.rs` |
 
 The browser sidebar is intentionally not a flat list of identical items.
-`ThreadListResponse` separates a dedicated `assistant_thread` field from the
-ordinary `threads` list. The frontend renders that assistant conversation into
-its own pinned `Assistant` row and renders every other stored conversation
-under the `Conversations` header. That means `Assistant` is the canonical
-gateway chat thread, not just the first item in the same list as user-created
-threads.
+`ThreadListResponse` carries the dedicated assistant conversation in
+`assistant_thread` and all other stored conversations in `threads`. The
+frontend turns that split into a pinned `Assistant` row plus a separate
+`Conversations` list, so the assistant conversation remains a distinct gateway
+chat surface rather than just another user-created thread.
 
 ## 4. End-to-end data flow
 
@@ -257,22 +256,65 @@ That hydration step matters because otherwise a browser reload or thread switch
 would create a fresh in-memory thread and split one logical conversation across
 two internal identifiers.
 
-The browser thread list adds another important distinction. The gateway keeps a
-dedicated assistant conversation for the `gateway` channel by calling
-`get_or_create_assistant_conversation()` when it builds
-`/api/chat/threads`. That conversation is removed from the ordinary
-conversation summaries and returned separately as `assistant_thread`, while the
-remaining persisted conversations are returned as `threads`.
+The browser thread list adds one browser-specific rule that is worth calling
+out once and directly. When the gateway builds `/api/chat/threads`, it calls
+`get_or_create_assistant_conversation()` for the literal `gateway` channel
+value used in the code. The returned conversation is emitted as
+`assistant_thread`, while the remaining summaries are emitted as `threads`.
 
-The frontend preserves that split. `loadThreads()` binds
-`assistant_thread.id` to a dedicated `assistantThreadId`, hard-codes its
-sidebar label to `Assistant`, and defaults to it on first load when no thread
-is selected. Ordinary conversations are rendered from `threads`,
-switched through `switchThread(thread.id)`, and titled from their stored title,
-channel, type, or UUID prefix. Creating a new thread through
-`POST /api/chat/thread/new` creates a regular `thread_type = "thread"`
-conversation and selects it, but it does not replace the pinned assistant
-conversation.
+The frontend preserves that contract in one place. `loadThreads()` stores
+`assistant_thread.id` as `assistantThreadId`, renders it as the pinned
+`Assistant` row, and defaults to it when no active thread is selected.
+Ordinary conversations come from `threads`, switch through
+`switchThread(thread.id)`, and keep their stored title, channel, type, or UUID
+prefix. Creating a new conversation through `POST /api/chat/thread/new`
+creates a regular conversation with the literal `thread_type = "thread"` value
+used in the implementation, then selects it without replacing the pinned
+assistant conversation.
+
+Figure 2. Accessible sequence diagram showing how the gateway returns the
+assistant conversation separately from ordinary thread summaries, how the
+browser renders that assistant thread as a pinned `Assistant` row, and how
+creating or switching regular conversations leaves the pinned assistant thread
+in place.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Browser
+    participant Gateway
+    participant ConversationStore
+
+    User->>Browser: Load chat UI
+    Browser->>Gateway: GET /api/chat/threads
+    Gateway->>ConversationStore: get_or_create_assistant_conversation(gateway_channel)
+    ConversationStore-->>Gateway: assistant_conversation
+    Gateway->>ConversationStore: list_conversation_summaries(excluding assistant)
+    ConversationStore-->>Gateway: conversation_summaries
+    Gateway-->>Browser: ThreadListResponse
+    Note over Gateway,Browser: assistant_thread = assistant_conversation
+    Note over Gateway,Browser: threads = conversation_summaries
+
+    Browser->>Browser: loadThreads(ThreadListResponse)
+    Browser->>Browser: assistantThreadId = assistant_thread.id
+    Browser->>Browser: Render pinned Assistant row using assistantThreadId
+    Browser->>Browser: Render Conversations list from threads
+    alt No active thread selected
+        Browser->>Browser: Select assistantThreadId as active thread
+    end
+
+    User->>Browser: Click conversation in Conversations list
+    Browser->>Browser: switchThread(thread.id)
+    Browser->>Gateway: GET /api/chat/history?thread_id=thread.id
+
+    User->>Browser: Create new conversation
+    Browser->>Gateway: POST /api/chat/thread/new
+    Gateway->>ConversationStore: create_conversation(thread_type = thread)
+    ConversationStore-->>Gateway: new_conversation
+    Gateway-->>Browser: new_conversation
+    Browser->>Browser: Select new_conversation.id as active
+    Note over Browser: Pinned Assistant row remains bound to assistantThreadId
+```
 
 ### 4.5 Safety validation and turn start
 


### PR DESCRIPTION
Document that the browser gateway returns the assistant conversation separately from ordinary threads and that the frontend preserves that split as a dedicated `Assistant` sidebar entry.

This keeps the chat model reference aligned with the current thread list DTOs and the actual gateway and frontend behaviour.

## Summary by Sourcery

Clarify how the browser gateway and frontend handle the pinned assistant chat thread separately from regular conversations in the chat model documentation.

Documentation:
- Document the `ThreadListResponse` DTO as the browser sidebar model for the assistant thread, regular threads, and active-thread selection.
- Explain that the gateway exposes the assistant conversation separately as `assistant_thread` and that the frontend renders it as a pinned `Assistant` entry distinct from ordinary conversations.