### PR TITLE
Split build_all into build_components and RuntimeSideEffects

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,6 +41,7 @@ jobs:
     name: Coverage (${{ matrix.name }})
     runs-on: ubuntu-latest
     env:
+      CARGO_INCREMENTAL: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
         -C link-arg=-fuse-ld=mold
@@ -72,6 +73,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
@@ -137,6 +148,14 @@ jobs:
           disable_search: true
           use_oidc: true
           fail_ci_if_error: true
+
+      - name: Trim build artefacts before cache save
+        if: always()
+        run: |
+          rm -rf target/debug/incremental
+          rm -rf target/debug/.fingerprint
+          cargo clean --doc 2>/dev/null || true
+          find target -name "*.d" -delete 2>/dev/null || true
 
   e2e-coverage:
     name: E2E Coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,7 +74,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -43,7 +43,7 @@ jobs:
         -C link-arg=-fuse-ld=mold
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -37,10 +37,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
+      CARGO_INCREMENTAL: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
         -C link-arg=-fuse-ld=mold
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -178,3 +189,11 @@ jobs:
           # Prevent a hard failure if cargo-mutants exits before creating
           # the output directory (e.g. internal error or misconfiguration).
           if-no-files-found: ignore
+
+      - name: Trim build artefacts before cache save
+        if: always()
+        run: |
+          rm -rf target/debug/incremental
+          rm -rf target/debug/.fingerprint
+          cargo clean --doc 2>/dev/null || true
+          find target -name "*.d" -delete 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasip2
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
       - name: Install mold
         uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
             flags: "--no-default-features --features libsql"
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     name: Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
     env:
+      CARGO_INCREMENTAL: "0"
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
         -C link-arg=-fuse-ld=mold
@@ -28,6 +29,16 @@ jobs:
           - name: libsql-only
             flags: "--no-default-features --features libsql"
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install Rust
@@ -54,6 +65,13 @@ jobs:
           make test
           NEXTEST_PROFILE=ci
           TEST_FEATURES="${{ matrix.flags }} --features test-helpers"
+      - name: Trim build artefacts before cache save
+        if: always()
+        run: |
+          rm -rf target/debug/incremental
+          rm -rf target/debug/.fingerprint
+          cargo clean --doc 2>/dev/null || true
+          find target -name "*.d" -delete 2>/dev/null || true
 
   telegram-tests:
     name: Telegram Channel Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -162,7 +162,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2182,7 +2182,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2476,6 +2476,17 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "filetime"
@@ -2731,6 +2742,16 @@ dependencies = [
  "fxhash",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -3535,6 +3556,7 @@ dependencies = [
  "flate2",
  "fs4",
  "futures",
+ "gag",
  "hex",
  "hkdf",
  "hmac 0.12.1",
@@ -4302,7 +4324,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5773,7 +5795,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6487,7 +6509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6718,7 +6740,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7560,7 +7582,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8428,7 +8450,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ proptest = "1.6.0"
 tempfile = "3"
 mockall = "0.13"
 trybuild = "1"
+gag = "1.0.0"
 
 [features]
 default = ["postgres", "libsql", "html-to-markdown", "docker"]

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -161,6 +161,7 @@ Table 2. AppBuilder phases and the state they add.
 | Secrets | Creates the encrypted secrets store when a master key is available, injects stored provider credentials into the config overlay, and falls back to operating system credentials when no encrypted store is available | LLM credential resolution intentionally happens more than once |
 | LLM | Builds the provider chain and any recording wrapper used for tracing | The chain is responsible for retry, failover, and routing decorators |
 | Tools and workspace | Creates the safety layer, tool registry, embedding provider, workspace memory, and optional image or builder tools | Workspace memory only exists when a database backend is active |
+| Skills | [`init_skills()`](./developers-guide.md#init_skills) discovers local and installed skills, wiring their tools into the ToolRegistry; returns registries as optional handles in AppComponents | Runs during construction only; RuntimeSideEffects does not load skills |
 | Extensions | Starts MCP session and process managers, creates the WASM runtime, loads runtime extensions, loads registry metadata, and creates the extension manager | The extension manager is registered back into the tool system so the agent can discover and manage extensions in chat |
 <!-- markdownlint-enable MD013 MD060 -->
 

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -70,7 +70,7 @@ flowchart TD
     Webhooks[HTTP and webhook channels]
     WasmChannels[WASM channels]
     Agent[Agent runtime]
-    AppBuilder[AppBuilder bootstrap]
+    AppBuilder[AppBuilder bootstrap / RuntimeSideEffects]
     Config[Config overlay]
     DB[(Database)]
     Workspace[Workspace memory]
@@ -132,9 +132,14 @@ before channels and background services start.
    behaviour while tests and internal callers use `Config::from_context(...)`
    for deterministic resolution. The database is not yet required at this
    point.
-6. `AppBuilder::build_all()` executes the mechanical initialization phases in a
-   fixed order: database, secrets, language model providers, tools and
-   workspace, then extensions.
+6. `AppBuilder::build_components()` executes the mechanical initialization
+   phases in a fixed order, returning `(AppComponents, RuntimeSideEffects)`.
+   In production `main.rs` calls `side_effects.start()` immediately
+   afterwards to activate deferred background work (stale job cleanup,
+   workspace import/seeding, embedding backfill). In tests the
+   `RuntimeSideEffects` value is discarded to avoid unnecessary I/O.
+   A backward-compatible `build_all()` wrapper calls both in sequence for
+   callers that do not need the separation.
 7. After core components exist, `async_main()` starts optional tunnel support,
    configures the sandbox orchestrator, wires interaction channels, registers
    hooks, and creates the agent.
@@ -158,6 +163,26 @@ Table 2. AppBuilder phases and the state they add.
 | Tools and workspace | Creates the safety layer, tool registry, embedding provider, workspace memory, and optional image or builder tools | Workspace memory only exists when a database backend is active |
 | Extensions | Starts MCP session and process managers, creates the WASM runtime, loads runtime extensions, loads registry metadata, and creates the extension manager | The extension manager is registered back into the tool system so the agent can discover and manage extensions in chat |
 <!-- markdownlint-enable MD013 MD060 -->
+
+#### 3.2.1 RuntimeSideEffects
+
+`AppBuilder::build_components()` returns a `RuntimeSideEffects` value
+alongside `AppComponents`. `RuntimeSideEffects` encapsulates deferred
+background work that must not run during tests:
+
+| Task | Trigger condition |
+| --- | --- |
+| Stale sandbox job cleanup | `db` is present |
+| Workspace import / seeding | `workspace` and `workspace_import_dir` are set |
+| Embedding backfill | `workspace` is present and `embeddings_available` is true |
+
+Call `side_effects.start()` once in `main.rs` after construction is
+complete. Tests discard the value to keep the test environment isolated.
+
+`AppBuilderFlags` has a `workspace_import_dir: Option<PathBuf>` field
+that captures the import directory at construction time (from the
+`WORKSPACE_IMPORT_DIR` environment variable in production) so that
+activation does not need to re-read the environment.
 
 ### 3.3 Long-running services
 

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -173,7 +173,8 @@ background work that must not run during tests:
 | Task | Trigger condition |
 | --- | --- |
 | Stale sandbox job cleanup | `db` is present |
-| Workspace import / seeding | `workspace` and `workspace_import_dir` are set |
+| Workspace import | `workspace` and `workspace_import_dir` are set |
+| Workspace seeding | `workspace` is present (`seed_if_empty()`) |
 | Embedding backfill | `workspace` is present and `embeddings_available` is true |
 
 Call `side_effects.start()` once in `main.rs` after construction is

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -170,6 +170,8 @@ Table 2. AppBuilder phases and the state they add.
 alongside `AppComponents`. `RuntimeSideEffects` encapsulates deferred
 background work that must not run during tests:
 
+Table: Runtime side-effect trigger conditions.
+
 | Task | Trigger condition |
 | --- | --- |
 | Stale sandbox job cleanup | `db` is present |

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -134,9 +134,9 @@ before channels and background services start.
    point.
 6. `AppBuilder::build_components()` executes the mechanical initialization
    phases in a fixed order, returning `(AppComponents, RuntimeSideEffects)`.
-   In production `main.rs` calls `side_effects.start()` immediately
+   In production, `main.rs` calls `side_effects.start()` immediately
    afterwards to activate deferred background work (stale job cleanup,
-   workspace import/seeding, embedding backfill). In tests the
+   workspace import/seeding, embedding backfill). In tests, the
    `RuntimeSideEffects` value is discarded to avoid unnecessary I/O.
    A backward-compatible `build_all()` wrapper calls both in sequence for
    callers that do not need the separation.
@@ -171,7 +171,7 @@ Table 2. AppBuilder phases and the state they add.
 alongside `AppComponents`. `RuntimeSideEffects` encapsulates deferred
 background work that must not run during tests:
 
-Table: Runtime side-effect trigger conditions.
+Table: Runtime side effect trigger conditions.
 
 | Task | Trigger condition |
 | --- | --- |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -184,6 +184,39 @@ For tests, prefer the helpers in `src/testing/test_utils.rs` or
 `Config::for_testing(...)` instead of mutating `std::env`. That keeps
 tests independent of host machine secrets, keychains, and shell state.
 
+## AppBuilder
+
+`AppBuilder` owns the mechanical bootstrap sequence for host startup.
+It constructs `AppComponents` in phase order and keeps activation of
+runtime side effects separate from construction so tests can avoid
+background I/O.
+
+### Two-phase bootstrap
+
+`build_components()` separates construction from activation:
+
+```rust
+// Production usage (src/main.rs):
+let (components, side_effects) = AppBuilder::new(…).build_components().await?;
+side_effects.start();   // activates background tasks
+
+// Test usage (tests/support/test_rig/builder.rs):
+let (components, _side_effects) = builder.build_components().await?;
+// _side_effects is intentionally discarded — no background I/O during tests
+```
+
+Use `build_all()` when you need the backward-compatible single-call form;
+it calls `build_components()` and `side_effects.start()` in sequence.
+
+#### AppBuilderFlags
+
+`AppBuilderFlags` controls optional construction behaviour:
+
+| Field | Type | Effect |
+| --- | --- | --- |
+| `no_db` | `bool` | Skip database initialisation |
+| `workspace_import_dir` | `Option<PathBuf>` | Directory to import into the workspace on activation; captured at construction so `RuntimeSideEffects::start()` does not re-read the environment |
+
 ## Fast local validation loop
 
 For quick host-side iteration on Linux or WSL with the current branch
@@ -206,7 +239,6 @@ cargo nextest run --workspace --no-default-features --features libsql \
 
 To compare behaviour against the legacy harness, use `make test-cargo`
 or `make test-matrix-cargo`.
-
 
 ## Self-repair internals
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -209,6 +209,30 @@ The `build_all()` function provides a backward-compatible single-call
 form; it invokes `build_components()` and then
 `side_effects.start()`.
 
+- `init_skills()` runs during `build_components()` construction;
+  `RuntimeSideEffects::start()` does not load skills.
+
+#### init_skills()
+
+Phase: after tool registry initialization and before extensions.
+Purpose: discover local and installed skills, register their tools into
+the shared `ToolRegistry`, and expose:
+
+- `SkillRegistry` (`Arc<RwLock<...>>`) for mutation by the agent at
+  runtime.
+- `SkillCatalog` (`Arc<...>`) for lookups.
+
+Behaviour:
+
+- When `config.skills.enabled = false` it returns `(None, None)`.
+- When enabled it loads skills from `skills.local_dir` and
+  `skills.installed_dir` (if present), logs loaded names at debug, and
+  registers tool shims into the `ToolRegistry`.
+
+Tests:
+
+- See `src/app.rs` `#[cfg(test)]` for smoke coverage.
+
 #### AppBuilderFlags
 
 `AppBuilderFlags` controls optional construction behaviour:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -205,16 +205,19 @@ let (components, _side_effects) = builder.build_components().await?;
 // _side_effects is intentionally discarded — no background I/O during tests
 ```
 
-Use `build_all()` when you need the backward-compatible single-call form;
-it calls `build_components()` and `side_effects.start()` in sequence.
+The `build_all()` function provides a backward-compatible single-call
+form; it invokes `build_components()` and then
+`side_effects.start()`.
 
 #### AppBuilderFlags
 
 `AppBuilderFlags` controls optional construction behaviour:
 
+Table: `AppBuilderFlags` fields and effects.
+
 | Field | Type | Effect |
 | --- | --- | --- |
-| `no_db` | `bool` | Skip database initialisation |
+| `no_db` | `bool` | Skip database initialization |
 | `workspace_import_dir` | `Option<PathBuf>` | Directory to import into the workspace on activation; captured at construction so `RuntimeSideEffects::start()` does not re-read the environment |
 
 ## Fast local validation loop

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -225,7 +225,7 @@ the shared `ToolRegistry`, and expose:
 Behaviour:
 
 - When `config.skills.enabled = false` it returns `(None, None)`.
-- When enabled it loads skills from `skills.local_dir` and
+- When enabled, it loads skills from `skills.local_dir` and
   `skills.installed_dir` (if present), logs loaded names at debug, and
   registers tool shims into the `ToolRegistry`.
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -292,7 +292,13 @@ impl Agent {
         params: &serde_json::Value,
         job_ctx: &JobContext,
     ) -> Result<String, Error> {
-        execute_chat_tool_standalone(self.tools(), self.safety(), tool_name, params, job_ctx).await
+        execute_chat_tool_standalone(
+            self.tools(),
+            self.safety(),
+            &ChatToolRequest { tool_name, params },
+            job_ctx,
+        )
+        .await
     }
 }
 
@@ -657,8 +663,10 @@ impl<'a> ChatDelegate<'a> {
                 let result = execute_chat_tool_standalone(
                     &tools,
                     &safety,
-                    &tc.name,
-                    &tc.arguments,
+                    &ChatToolRequest {
+                        tool_name: &tc.name,
+                        params: &tc.arguments,
+                    },
                     &job_ctx,
                 )
                 .await;
@@ -1116,6 +1124,11 @@ impl<'a> NativeLoopDelegate for ChatDelegate<'a> {
     }
 }
 
+/// Describes a single tool invocation passed to `execute_chat_tool_standalone`.
+pub(crate) struct ChatToolRequest<'a> {
+    pub(crate) tool_name: &'a str,
+    pub(crate) params: &'a serde_json::Value,
+}
 /// Execute a chat tool without requiring `&Agent`.
 ///
 /// This standalone function enables parallel invocation from spawned JoinSet
@@ -1124,11 +1137,17 @@ impl<'a> NativeLoopDelegate for ChatDelegate<'a> {
 pub(super) async fn execute_chat_tool_standalone(
     tools: &crate::tools::ToolRegistry,
     safety: &crate::safety::SafetyLayer,
-    tool_name: &str,
-    params: &serde_json::Value,
+    request: &ChatToolRequest<'_>,
     job_ctx: &crate::context::JobContext,
 ) -> Result<String, Error> {
-    crate::tools::execute::execute_tool_with_safety(tools, safety, tool_name, params, job_ctx).await
+    crate::tools::execute::execute_tool_with_safety(
+        tools,
+        safety,
+        request.tool_name,
+        request.params,
+        job_ctx,
+    )
+    .await
 }
 
 /// Parsed auth result fields for emitting StatusUpdate::AuthRequired.
@@ -1692,8 +1711,10 @@ mod tests {
         let result = super::execute_chat_tool_standalone(
             &registry,
             &safety,
-            "echo",
-            &serde_json::json!({"message": "hello"}),
+            &super::ChatToolRequest {
+                tool_name: "echo",
+                params: &serde_json::json!({"message": "hello"}),
+            },
             &job_ctx,
         )
         .await;
@@ -1720,8 +1741,10 @@ mod tests {
         let result = super::execute_chat_tool_standalone(
             &registry,
             &safety,
-            "nonexistent",
-            &serde_json::json!({}),
+            &super::ChatToolRequest {
+                tool_name: "nonexistent",
+                params: &serde_json::json!({}),
+            },
             &job_ctx,
         )
         .await;

--- a/src/agent/thread_ops/approval.rs
+++ b/src/agent/thread_ops/approval.rs
@@ -40,7 +40,8 @@ use uuid::Uuid;
 
 use crate::agent::Agent;
 use crate::agent::dispatcher::{
-    AgenticLoopResult, check_auth_required, execute_chat_tool_standalone, parse_auth_result,
+    AgenticLoopResult, ChatToolRequest, check_auth_required, execute_chat_tool_standalone,
+    parse_auth_result,
 };
 use crate::agent::session::{PendingApproval, Session, ThreadState};
 use crate::agent::submission::SubmissionResult;
@@ -549,8 +550,10 @@ impl Agent {
                 let result = execute_chat_tool_standalone(
                     &tools,
                     &safety,
-                    &tc.name,
-                    &tc.arguments,
+                    &ChatToolRequest {
+                        tool_name: &tc.name,
+                        params: &tc.arguments,
+                    },
                     &job_ctx,
                 )
                 .await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,21 @@
 //! - Tests can construct a full `AppComponents` without wiring channels
 //! - Main stays focused on CLI dispatch and channel setup
 //! - Each init phase is independently testable
+//!
+//! ## Two-phase bootstrap pattern
+//!
+//! This module follows a hexagonal architecture principle: **keep assembly
+//! distinct from mechanism-heavy activation**. Construction of components
+//! (the `AppBuilder`) is separated from fire-and-forget runtime side effects
+//! (the `RuntimeSideEffects`).
+//!
+//! - Use `build_components()` when you need control over side-effect timing
+//!   (e.g., in tests where I/O and background tasks should be avoided).
+//! - Use `build_all()` as a convenience wrapper that constructs components
+//!   and immediately starts side effects — suitable for production startup.
+//!
+//! The `RuntimeSideEffects::start()` method is fire-and-forget; callers need
+//! not await unless ordering guarantees are required.
 
 use std::sync::Arc;
 
@@ -55,8 +70,19 @@ pub struct AppComponents {
     pub dev_loaded_tool_names: Vec<String>,
 }
 
-/// Options that control optional init phases.
-#[derive(Default)]
+/// Deferred runtime side effects that should be started after component
+/// construction is complete.
+///
+/// This struct encapsulates fire-and-forget background tasks (stale job cleanup,
+/// workspace import/seeding, embedding backfill) that are activated separately
+/// from pure construction. Following hexagonal architecture principles, this
+/// separates assembly from activation.
+pub struct RuntimeSideEffects {
+    db: Option<Arc<dyn Database>>,
+    workspace: Option<Arc<Workspace>>,
+    workspace_import_dir: Option<std::path::PathBuf>,
+    embeddings_available: bool,
+}
 pub struct AppBuilderFlags {
     pub no_db: bool,
 }
@@ -171,13 +197,8 @@ impl AppBuilder {
 
         self.session.attach_store(db.clone(), "default").await;
 
-        // Fire-and-forget housekeeping — no need to block startup.
-        let db_cleanup = db.clone();
-        tokio::spawn(async move {
-            if let Err(e) = db_cleanup.cleanup_stale_sandbox_jobs().await {
-                tracing::warn!("Failed to cleanup stale sandbox jobs: {}", e);
-            }
-        });
+        // Note: stale job cleanup is now handled by RuntimeSideEffects::start()
+        // to separate construction from activation side effects.
 
         self.db = Some(db);
         Ok(())
@@ -418,8 +439,16 @@ impl AppBuilder {
         .await
     }
 
-    /// Run all init phases in order and return the assembled components.
-    pub async fn build_all(mut self) -> Result<AppComponents, anyhow::Error> {
+    /// Run all init phases in order and return the assembled components
+    /// along with deferred runtime side effects.
+    ///
+    /// This method performs pure construction without activating background
+    /// tasks or I/O-heavy operations. Call `side_effects.start().await` to
+    /// activate deferred work (workspace import, seeding, embedding backfill,
+    /// stale job cleanup).
+    pub async fn build_components(
+        mut self,
+    ) -> Result<(AppComponents, RuntimeSideEffects), anyhow::Error> {
         self.init_database().await?;
         self.init_secrets().await?;
 
@@ -453,55 +482,10 @@ impl AppBuilder {
             dev_loaded_tool_names,
         ) = self.init_extensions(&tools, &hooks).await?;
 
-        // Seed workspace and backfill embeddings
-        if let Some(ref ws) = workspace {
-            // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
-            // This lets Docker images / deployment scripts ship customized
-            // workspace templates (e.g., AGENTS.md, TOOLS.md) that override
-            // the generic seeds. Only imports files that don't already exist
-            // in the database — never overwrites user edits.
-            //
-            // Runs before seed_if_empty() so that custom templates take priority
-            // over generic seeds. seed_if_empty() then fills any remaining gaps.
-            if let Ok(import_dir) = std::env::var("WORKSPACE_IMPORT_DIR") {
-                let import_path = std::path::Path::new(&import_dir);
-                match ws.import_from_directory(import_path).await {
-                    Ok(count) if count > 0 => {
-                        tracing::debug!("Imported {} workspace file(s) from {}", count, import_dir);
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to import workspace files from {}: {}",
-                            import_dir,
-                            e
-                        );
-                    }
-                }
-            }
-
-            match ws.seed_if_empty().await {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!("Failed to seed workspace: {}", e);
-                }
-            }
-
-            if embeddings.is_some() {
-                let ws_bg = Arc::clone(ws);
-                tokio::spawn(async move {
-                    match ws_bg.backfill_embeddings().await {
-                        Ok(count) if count > 0 => {
-                            tracing::debug!("Backfilled embeddings for {} chunks", count);
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            tracing::warn!("Failed to backfill embeddings: {}", e);
-                        }
-                    }
-                });
-            }
-        }
+        // Capture workspace import directory for deferred side effects.
+        let workspace_import_dir = std::env::var("WORKSPACE_IMPORT_DIR")
+            .ok()
+            .map(std::path::PathBuf::from);
 
         // Skills system
         let (skill_registry, skill_catalog) = if self.config.skills.enabled {
@@ -532,16 +516,17 @@ impl AppBuilder {
             tools.count()
         );
 
-        Ok(AppComponents {
+        let embeddings_available = embeddings.is_some();
+        let components = AppComponents {
             config: self.config,
-            db: self.db,
+            db: self.db.clone(),
             secrets_store: self.secrets_store,
             llm,
             cheap_llm,
             safety,
             tools,
             embeddings,
-            workspace,
+            workspace: workspace.clone(),
             extension_manager,
             mcp_session_manager,
             mcp_process_manager,
@@ -556,6 +541,117 @@ impl AppBuilder {
             session: self.session,
             catalog_entries,
             dev_loaded_tool_names,
-        })
+        };
+
+        let side_effects = RuntimeSideEffects::new(
+            self.db,
+            workspace,
+            workspace_import_dir,
+            embeddings_available,
+        );
+
+        Ok((components, side_effects))
+    }
+
+    /// Convenience wrapper that builds components and immediately starts
+    /// runtime side effects.
+    ///
+    /// This is equivalent to calling `build_components()` followed by
+    /// `side_effects.start().await`. Use `build_components()` directly when
+    /// you need control over side-effect timing (e.g., in tests).
+    pub async fn build_all(self) -> Result<AppComponents, anyhow::Error> {
+        let (components, side_effects) = self.build_components().await?;
+        side_effects.start().await;
+        Ok(components)
+    }
+}
+
+impl RuntimeSideEffects {
+    /// Create a new `RuntimeSideEffects` instance.
+    pub fn new(
+        db: Option<Arc<dyn Database>>,
+        workspace: Option<Arc<Workspace>>,
+        workspace_import_dir: Option<std::path::PathBuf>,
+        embeddings_available: bool,
+    ) -> Self {
+        Self {
+            db,
+            workspace,
+            workspace_import_dir,
+            embeddings_available,
+        }
+    }
+
+    /// Start all deferred runtime side effects.
+    ///
+    /// This method is fire-and-forget; it spawns background tasks and returns
+    /// immediately. Callers need not await unless ordering guarantees are required
+    /// (e.g., ensuring side effects start before accepting requests).
+    ///
+    /// Side effects include:
+    /// - Stale sandbox job cleanup (via database)
+    /// - Workspace import from disk (if `WORKSPACE_IMPORT_DIR` is set)
+    /// - Workspace seeding (if workspace is empty)
+    /// - Embedding backfill (spawns a background task)
+    pub async fn start(self) {
+        // Spawn stale sandbox cleanup task if database is available.
+        if let Some(db) = self.db {
+            tokio::spawn(async move {
+                if let Err(e) = db.cleanup_stale_sandbox_jobs().await {
+                    tracing::warn!("Failed to cleanup stale sandbox jobs: {}", e);
+                }
+            });
+        }
+
+        // Run workspace import, seeding, and embedding backfill if workspace is available.
+        if let Some(ws) = self.workspace {
+            // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
+            // This lets Docker images / deployment scripts ship customized workspace
+            // templates that override generic seeds. Only imports files that don't
+            // already exist in the database — never overwrites user edits.
+            if let Some(import_dir) = self.workspace_import_dir {
+                match ws.import_from_directory(&import_dir).await {
+                    Ok(count) if count > 0 => {
+                        tracing::debug!(
+                            "Imported {} workspace file(s) from {}",
+                            count,
+                            import_dir.display()
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to import workspace files from {}: {}",
+                            import_dir.display(),
+                            e
+                        );
+                    }
+                }
+            }
+
+            // Seed workspace with default content if empty.
+            match ws.seed_if_empty().await {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("Failed to seed workspace: {}", e);
+                }
+            }
+
+            // Spawn embedding backfill in background if embeddings are configured.
+            if self.embeddings_available {
+                let ws_bg = Arc::clone(&ws);
+                tokio::spawn(async move {
+                    match ws_bg.backfill_embeddings().await {
+                        Ok(count) if count > 0 => {
+                            tracing::debug!("Backfilled embeddings for {} chunks", count);
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!("Failed to backfill embeddings: {}", e);
+                        }
+                    }
+                });
+            }
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,6 +83,8 @@ pub struct RuntimeSideEffects {
     workspace_import_dir: Option<std::path::PathBuf>,
     embeddings_available: bool,
 }
+/// Options that control optional init phases.
+#[derive(Default)]
 pub struct AppBuilderFlags {
     pub no_db: bool,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -647,7 +647,7 @@ impl RuntimeSideEffects {
         }
 
         // Run workspace import, seeding, and embedding backfill if workspace is available.
-        if let Some(ws) = self.workspace {
+        if let Some(ref ws) = self.workspace {
             // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
             // This lets Docker images / deployment scripts ship customized workspace
             // templates that override generic seeds. Only imports files that don't
@@ -682,7 +682,7 @@ impl RuntimeSideEffects {
 
             // Spawn embedding backfill in background if embeddings are configured.
             if self.embeddings_available {
-                let ws_bg = Arc::clone(&ws);
+                let ws_bg = Arc::clone(ws);
                 tokio::spawn(async move {
                     match ws_bg.backfill_embeddings().await {
                         Ok(count) if count > 0 => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -705,6 +705,23 @@ impl RuntimeSideEffects {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
+
+    use crate::{
+        channels::web::log_layer::LogBroadcaster,
+        config::Config,
+        db::Database,
+        llm::{LlmProvider, SessionConfig, SessionManager},
+        testing::StubLlm,
+    };
+    use anyhow::Context;
+    use tokio::time::{Duration, Instant};
+
+    #[cfg(feature = "libsql")]
+    use crate::db::libsql::LibSqlBackend;
 
     #[test]
     fn runtime_side_effects_new_all_none_does_not_panic() {
@@ -718,17 +735,48 @@ mod tests {
         se.start();
     }
 
-    #[cfg(feature = "libsql")]
-    #[tokio::test]
-    async fn build_components_returns_without_activating_side_effects() -> anyhow::Result<()> {
-        use crate::config::Config;
-        use crate::db::Database;
-        use crate::db::libsql::LibSqlBackend;
-        use crate::llm::SessionConfig;
-        use crate::testing::StubLlm;
-        use anyhow::Context;
-        use tokio::time::{Duration, Instant};
+    async fn assert_no_activation(
+        workspace: &Arc<Workspace>,
+        import_dir: &Path,
+    ) -> anyhow::Result<()> {
+        assert!(
+            tokio::fs::try_exists(import_dir.join("MARKER.md")).await?,
+            "build_components() must not mutate the source import directory"
+        );
+        assert!(
+            !workspace.exists("MARKER.md").await?,
+            "build_components() must not run deferred workspace import"
+        );
+        assert!(
+            !workspace.exists(crate::workspace::paths::README).await?,
+            "build_components() must not run seed_if_empty()"
+        );
+        Ok(())
+    }
 
+    async fn wait_for_import_and_seed(
+        workspace: &Arc<Workspace>,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+        loop {
+            if workspace.exists("MARKER.md").await?
+                && workspace.exists(crate::workspace::paths::README).await?
+            {
+                break;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "RuntimeSideEffects::start() did not import MARKER.md and seed the workspace in time"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "libsql")]
+    async fn two_phase_fixture() -> anyhow::Result<(AppBuilder, PathBuf, tempfile::TempDir)> {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("app-builder-test.db");
         let backend = LibSqlBackend::new_local(&db_path).await?;
@@ -765,42 +813,22 @@ mod tests {
         builder.with_database(db);
         builder.with_llm(llm);
 
+        Ok((builder, workspace_import_dir, temp_dir))
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn build_components_returns_without_activating_side_effects() -> anyhow::Result<()> {
+        let (builder, workspace_import_dir, _temp_dir) = two_phase_fixture().await?;
         let (components, side_effects) = builder.build_components().await?;
         assert!(components.tools.count() > 0);
         let workspace = components
             .workspace
             .as_ref()
             .context("workspace should be constructed during build_components()")?;
-        assert!(
-            tokio::fs::try_exists(workspace_import_dir.join("MARKER.md")).await?,
-            "build_components() must not mutate the source import directory"
-        );
-        assert!(
-            !workspace.exists("MARKER.md").await?,
-            "build_components() must not run deferred workspace import"
-        );
-        assert!(
-            !workspace.exists(crate::workspace::paths::README).await?,
-            "build_components() must not run seed_if_empty()"
-        );
-
+        assert_no_activation(workspace, &workspace_import_dir).await?;
         side_effects.start();
-
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            if workspace.exists("MARKER.md").await?
-                && workspace.exists(crate::workspace::paths::README).await?
-            {
-                break;
-            }
-            if Instant::now() >= deadline {
-                anyhow::bail!(
-                    "RuntimeSideEffects::start() did not import MARKER.md and seed the workspace in time"
-                );
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-
+        wait_for_import_and_seed(workspace, 5).await?;
         let marker = workspace.read("MARKER.md").await?;
         assert_eq!(
             marker.content,

--- a/src/app.rs
+++ b/src/app.rs
@@ -468,6 +468,41 @@ impl AppBuilder {
         .await
     }
 
+    /// Resolves the LLM provider: returns the injected override if present,
+    /// otherwise delegates to `init_llm()`.
+    async fn resolve_llm(
+        &mut self,
+    ) -> Result<
+        (
+            Arc<dyn LlmProvider>,
+            Option<Arc<dyn LlmProvider>>,
+            Option<Arc<RecordingLlm>>,
+        ),
+        anyhow::Error,
+    > {
+        if let Some(llm) = self.llm_override.take() {
+            return Ok((llm, None, None));
+        }
+        self.init_llm().await
+    }
+
+    /// Phase 7: Initialise runtime metering (context manager and cost guard).
+    fn init_metering(
+        &self,
+    ) -> (
+        Arc<ContextManager>,
+        Arc<crate::agent::cost_guard::CostGuard>,
+    ) {
+        let context_manager = Arc::new(ContextManager::new(self.config.agent.max_parallel_jobs));
+        let cost_guard = Arc::new(crate::agent::cost_guard::CostGuard::new(
+            crate::agent::cost_guard::CostGuardConfig {
+                max_cost_per_day_cents: self.config.agent.max_cost_per_day_cents,
+                max_actions_per_hour: self.config.agent.max_actions_per_hour,
+            },
+        ));
+        (context_manager, cost_guard)
+    }
+
     /// Validates that LLM credentials are configured for non-nearai backends.
     fn validate_llm_config(&self) -> Result<(), anyhow::Error> {
         if self.config.llm.backend != "nearai" && self.config.llm.provider.is_none() {
@@ -494,11 +529,7 @@ impl AppBuilder {
         self.init_secrets().await?;
         self.validate_llm_config()?;
 
-        let (llm, cheap_llm, recording_handle) = if let Some(llm) = self.llm_override.take() {
-            (llm, None, None)
-        } else {
-            self.init_llm().await?
-        };
+        let (llm, cheap_llm, recording_handle) = self.resolve_llm().await?;
         let (safety, tools, embeddings, workspace) = self.init_tools(&llm).await?;
 
         // Create hook registry early so runtime extension activation can register hooks.
@@ -521,13 +552,7 @@ impl AppBuilder {
         // Skills system
         let (skill_registry, skill_catalog) = self.init_skills(&tools).await?;
 
-        let context_manager = Arc::new(ContextManager::new(self.config.agent.max_parallel_jobs));
-        let cost_guard = Arc::new(crate::agent::cost_guard::CostGuard::new(
-            crate::agent::cost_guard::CostGuardConfig {
-                max_cost_per_day_cents: self.config.agent.max_cost_per_day_cents,
-                max_actions_per_hour: self.config.agent.max_actions_per_hour,
-            },
-        ));
+        let (context_manager, cost_guard) = self.init_metering();
 
         tracing::debug!(
             "Tool registry initialized with {} total tools",

--- a/src/app.rs
+++ b/src/app.rs
@@ -726,6 +726,8 @@ mod tests {
         use crate::db::libsql::LibSqlBackend;
         use crate::llm::SessionConfig;
         use crate::testing::StubLlm;
+        use anyhow::Context;
+        use tokio::time::{Duration, Instant};
 
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("app-builder-test.db");
@@ -735,8 +737,15 @@ mod tests {
 
         let skills_dir = temp_dir.path().join("skills");
         let installed_skills_dir = temp_dir.path().join("installed_skills");
+        let workspace_import_dir = temp_dir.path().join("workspace_import");
         tokio::fs::create_dir_all(&skills_dir).await?;
         tokio::fs::create_dir_all(&installed_skills_dir).await?;
+        tokio::fs::create_dir_all(&workspace_import_dir).await?;
+        tokio::fs::write(
+            workspace_import_dir.join("MARKER.md"),
+            "# Marker\n\nImported by RuntimeSideEffects::start().\n",
+        )
+        .await?;
 
         let config = Config::for_testing(db_path, skills_dir, installed_skills_dir).await?;
         let session = Arc::new(SessionManager::new(SessionConfig::default()));
@@ -745,7 +754,10 @@ mod tests {
 
         let mut builder = AppBuilder::new(
             config,
-            AppBuilderFlags::default(),
+            AppBuilderFlags {
+                workspace_import_dir: Some(workspace_import_dir.clone()),
+                ..AppBuilderFlags::default()
+            },
             None,
             session,
             log_broadcaster,
@@ -753,8 +765,47 @@ mod tests {
         builder.with_database(db);
         builder.with_llm(llm);
 
-        let (components, _side_effects) = builder.build_components().await?;
+        let (components, side_effects) = builder.build_components().await?;
         assert!(components.tools.count() > 0);
+        let workspace = components
+            .workspace
+            .as_ref()
+            .context("workspace should be constructed during build_components()")?;
+        assert!(
+            tokio::fs::try_exists(workspace_import_dir.join("MARKER.md")).await?,
+            "build_components() must not mutate the source import directory"
+        );
+        assert!(
+            !workspace.exists("MARKER.md").await?,
+            "build_components() must not run deferred workspace import"
+        );
+        assert!(
+            !workspace.exists(crate::workspace::paths::README).await?,
+            "build_components() must not run seed_if_empty()"
+        );
+
+        side_effects.start();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if workspace.exists("MARKER.md").await?
+                && workspace.exists(crate::workspace::paths::README).await?
+            {
+                break;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "RuntimeSideEffects::start() did not import MARKER.md and seed the workspace in time"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        let marker = workspace.read("MARKER.md").await?;
+        assert_eq!(
+            marker.content,
+            "# Marker\n\nImported by RuntimeSideEffects::start().\n"
+        );
 
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,11 +16,11 @@
 //!
 //! - Use `build_components()` when you need control over side-effect timing
 //!   (e.g., in tests where I/O and background tasks should be avoided).
-//! - Use `build_all()` as a convenience wrapper that constructs components
-//!   and immediately starts side effects — suitable for production startup.
+//! - Use `build_all()` as a convenience wrapper that constructs components,
+//!   starts side effects, and waits for workspace bootstrap to finish.
 //!
-//! The `RuntimeSideEffects::start()` method is fire-and-forget; callers need
-//! not await unless ordering guarantees are required.
+//! The `RuntimeSideEffects::start()` method returns task handles so callers
+//! can choose whether to detach runtime work or await workspace bootstrap.
 
 use std::sync::Arc;
 
@@ -40,6 +40,7 @@ use crate::tools::wasm::SharedCredentialRegistry;
 use crate::tools::wasm::WasmToolRuntime;
 use crate::tools::{ImageToolsRegistration, ToolRegistry, VisionToolsRegistration};
 use crate::workspace::{EmbeddingProvider, Workspace};
+use anyhow::Context;
 
 /// Fully initialized application components, ready for channel wiring
 /// and agent construction.
@@ -82,6 +83,24 @@ pub struct RuntimeSideEffects {
     workspace: Option<Arc<Workspace>>,
     workspace_import_dir: Option<std::path::PathBuf>,
     embeddings_available: bool,
+}
+
+/// Join handles for deferred runtime side effects.
+pub struct RuntimeSideEffectsHandle {
+    workspace_bootstrap: Option<tokio::task::JoinHandle<()>>,
+    _cleanup: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl RuntimeSideEffectsHandle {
+    /// Wait until workspace bootstrap work has finished.
+    pub async fn wait_until_bootstrapped(self) -> Result<(), anyhow::Error> {
+        if let Some(handle) = self.workspace_bootstrap {
+            handle
+                .await
+                .map_err(|e| anyhow::anyhow!("Workspace bootstrap task failed: {}", e))?;
+        }
+        Ok(())
+    }
 }
 
 /// Options that control optional init phases.
@@ -601,12 +620,13 @@ impl AppBuilder {
     /// Convenience wrapper that builds components and immediately starts
     /// runtime side effects.
     ///
-    /// This is equivalent to calling `build_components()` followed by
-    /// `side_effects.start()`. Use `build_components()` directly when
-    /// you need control over side-effect timing (e.g., in tests).
+    /// This is equivalent to calling `build_components()`, then
+    /// `side_effects.start()`, then awaiting workspace bootstrap completion.
+    /// Use `build_components()` directly when you need control over
+    /// side-effect timing (e.g., in tests).
     pub async fn build_all(self) -> Result<AppComponents, anyhow::Error> {
         let (components, side_effects) = self.build_components().await?;
-        side_effects.start();
+        side_effects.start()?.wait_until_bootstrapped().await?;
         Ok(components)
     }
 }
@@ -629,30 +649,37 @@ impl RuntimeSideEffects {
 
     /// Start all deferred runtime side effects.
     ///
-    /// This method is fire-and-forget; it spawns background tasks and returns
-    /// immediately. Callers need not await.
+    /// This method spawns background tasks and returns their handles. Callers
+    /// can drop the returned value to detach the work, or await
+    /// `wait_until_bootstrapped()` when ordering guarantees are required.
     ///
     /// Side effects include:
     /// - Stale sandbox job cleanup (via database)
     /// - Workspace import from disk (if `WORKSPACE_IMPORT_DIR` is set)
     /// - Workspace seeding (if workspace is empty)
     /// - Embedding backfill (spawns a background task)
-    pub fn start(self) {
+    pub fn start(self) -> Result<RuntimeSideEffectsHandle, anyhow::Error> {
         // Spawn stale sandbox cleanup task if database is available.
-        if let Some(db) = self.db {
-            tokio::spawn(async move {
+        let cleanup = if let Some(db) = self.db {
+            let handle = tokio::runtime::Handle::try_current()
+                .context("RuntimeSideEffects::start() requires a Tokio runtime")?;
+            Some(handle.spawn(async move {
                 if let Err(e) = db.cleanup_stale_sandbox_jobs().await {
                     tracing::warn!("Failed to cleanup stale sandbox jobs: {}", e);
                 }
-            });
-        }
+            }))
+        } else {
+            None
+        };
 
         // Spawn workspace import, seeding, and embedding backfill if workspace is available.
-        if let Some(ws) = self.workspace {
+        let workspace_bootstrap = if let Some(ws) = self.workspace {
             let import_dir = self.workspace_import_dir;
             let embeddings_available = self.embeddings_available;
+            let handle = tokio::runtime::Handle::try_current()
+                .context("RuntimeSideEffects::start() requires a Tokio runtime")?;
 
-            tokio::spawn(async move {
+            Some(handle.spawn(async move {
                 // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
                 // This lets Docker images / deployment scripts ship customized workspace
                 // templates that override generic seeds. Only imports files that don't
@@ -697,8 +724,15 @@ impl RuntimeSideEffects {
                         }
                     }
                 }
-            });
-        }
+            }))
+        } else {
+            None
+        };
+
+        Ok(RuntimeSideEffectsHandle {
+            workspace_bootstrap,
+            _cleanup: cleanup,
+        })
     }
 }
 
@@ -729,10 +763,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_side_effects_start_no_ops_when_nothing_configured() {
+    async fn runtime_side_effects_start_no_ops_when_nothing_configured() -> anyhow::Result<()> {
         let se = RuntimeSideEffects::new(None, None, None, false);
-        // start() returns () — the test passes if it does not panic.
-        se.start();
+        se.start()?.wait_until_bootstrapped().await?;
+        Ok(())
     }
 
     async fn assert_no_activation(
@@ -827,14 +861,31 @@ mod tests {
             .as_ref()
             .context("workspace should be constructed during build_components()")?;
         assert_no_activation(workspace, &workspace_import_dir).await?;
-        side_effects.start();
-        wait_for_import_and_seed(workspace, 5).await?;
+        side_effects.start()?.wait_until_bootstrapped().await?;
         let marker = workspace.read("MARKER.md").await?;
         assert_eq!(
             marker.content,
             "# Marker\n\nImported by RuntimeSideEffects::start().\n"
         );
 
+        Ok(())
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn build_all_waits_for_workspace_bootstrap() -> anyhow::Result<()> {
+        let (builder, _workspace_import_dir, _temp_dir) = two_phase_fixture().await?;
+        let components = builder.build_all().await?;
+        let workspace = components
+            .workspace
+            .as_ref()
+            .context("workspace should be constructed during build_all()")?;
+        wait_for_import_and_seed(workspace, 0).await?;
+        let marker = workspace.read("MARKER.md").await?;
+        assert_eq!(
+            marker.content,
+            "# Marker\n\nImported by RuntimeSideEffects::start().\n"
+        );
         Ok(())
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -413,6 +413,33 @@ impl AppBuilder {
         Ok((safety, tools, embeddings, workspace))
     }
 
+    /// Phase 6: Initialise the skills system.
+    pub async fn init_skills(
+        &self,
+        tools: &Arc<ToolRegistry>,
+    ) -> Result<
+        (
+            Option<Arc<std::sync::RwLock<SkillRegistry>>>,
+            Option<Arc<SkillCatalog>>,
+        ),
+        anyhow::Error,
+    > {
+        if !self.config.skills.enabled {
+            return Ok((None, None));
+        }
+
+        let mut registry = SkillRegistry::new(self.config.skills.local_dir.clone())
+            .with_installed_dir(self.config.skills.installed_dir.clone());
+        let loaded = registry.discover_all().await;
+        if !loaded.is_empty() {
+            tracing::debug!("Loaded {} skill(s): {}", loaded.len(), loaded.join(", "));
+        }
+        let registry = Arc::new(std::sync::RwLock::new(registry));
+        let catalog = crate::skills::catalog::shared_catalog();
+        tools.register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
+        Ok((Some(registry), Some(catalog)))
+    }
+
     /// Phase 5: Load WASM tools, MCP servers, and create extension manager.
     pub async fn init_extensions(
         &self,
@@ -441,6 +468,18 @@ impl AppBuilder {
         .await
     }
 
+    /// Validates that LLM credentials are configured for non-nearai backends.
+    fn validate_llm_config(&self) -> Result<(), anyhow::Error> {
+        if self.config.llm.backend != "nearai" && self.config.llm.provider.is_none() {
+            let backend = &self.config.llm.backend;
+            anyhow::bail!(
+                "LLM_BACKEND={backend} is configured but no credentials were found. \
+                 Set the appropriate API key environment variable or run the setup wizard."
+            );
+        }
+        Ok(())
+    }
+
     /// Run all init phases in order and return the assembled components
     /// along with deferred runtime side effects.
     ///
@@ -453,17 +492,7 @@ impl AppBuilder {
     ) -> Result<(AppComponents, RuntimeSideEffects), anyhow::Error> {
         self.init_database().await?;
         self.init_secrets().await?;
-
-        // Post-init validation: if a non-nearai backend was selected but
-        // credentials were never resolved (deferred resolution found no keys),
-        // fail early with a clear error instead of a confusing runtime failure.
-        if self.config.llm.backend != "nearai" && self.config.llm.provider.is_none() {
-            let backend = &self.config.llm.backend;
-            anyhow::bail!(
-                "LLM_BACKEND={backend} is configured but no credentials were found. \
-                 Set the appropriate API key environment variable or run the setup wizard."
-            );
-        }
+        self.validate_llm_config()?;
 
         let (llm, cheap_llm, recording_handle) = if let Some(llm) = self.llm_override.take() {
             (llm, None, None)
@@ -490,20 +519,7 @@ impl AppBuilder {
             .map(std::path::PathBuf::from);
 
         // Skills system
-        let (skill_registry, skill_catalog) = if self.config.skills.enabled {
-            let mut registry = SkillRegistry::new(self.config.skills.local_dir.clone())
-                .with_installed_dir(self.config.skills.installed_dir.clone());
-            let loaded = registry.discover_all().await;
-            if !loaded.is_empty() {
-                tracing::debug!("Loaded {} skill(s): {}", loaded.len(), loaded.join(", "));
-            }
-            let registry = Arc::new(std::sync::RwLock::new(registry));
-            let catalog = crate::skills::catalog::shared_catalog();
-            tools.register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
-            (Some(registry), Some(catalog))
-        } else {
-            (None, None)
-        };
+        let (skill_registry, skill_catalog) = self.init_skills(&tools).await?;
 
         let context_manager = Arc::new(ContextManager::new(self.config.agent.max_parallel_jobs));
         let cost_guard = Arc::new(crate::agent::cost_guard::CostGuard::new(

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,10 +83,13 @@ pub struct RuntimeSideEffects {
     workspace_import_dir: Option<std::path::PathBuf>,
     embeddings_available: bool,
 }
+
 /// Options that control optional init phases.
 #[derive(Default)]
 pub struct AppBuilderFlags {
     pub no_db: bool,
+    /// Workspace import directory (overrides WORKSPACE_IMPORT_DIR env var if set).
+    pub workspace_import_dir: Option<std::path::PathBuf>,
 }
 
 /// Builder that orchestrates the 5 mechanical init phases.
@@ -413,7 +416,7 @@ impl AppBuilder {
         Ok((safety, tools, embeddings, workspace))
     }
 
-    /// Phase 6: Initialise the skills system.
+    /// Phase 5: Initialise the skills system.
     pub async fn init_skills(
         &self,
         tools: &Arc<ToolRegistry>,
@@ -440,7 +443,7 @@ impl AppBuilder {
         Ok((Some(registry), Some(catalog)))
     }
 
-    /// Phase 5: Load WASM tools, MCP servers, and create extension manager.
+    /// Phase 6: Load WASM tools, MCP servers, and create extension manager.
     pub async fn init_extensions(
         &self,
         tools: &Arc<ToolRegistry>,
@@ -545,9 +548,7 @@ impl AppBuilder {
         ) = self.init_extensions(&tools, &hooks).await?;
 
         // Capture workspace import directory for deferred side effects.
-        let workspace_import_dir = std::env::var("WORKSPACE_IMPORT_DIR")
-            .ok()
-            .map(std::path::PathBuf::from);
+        let workspace_import_dir = self.flags.workspace_import_dir.clone();
 
         // Skills system
         let (skill_registry, skill_catalog) = self.init_skills(&tools).await?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -416,7 +416,7 @@ impl AppBuilder {
         Ok((safety, tools, embeddings, workspace))
     }
 
-    /// Phase 5: Initialise the skills system.
+    /// Phase 5: Initialize the skills system.
     pub async fn init_skills(
         &self,
         tools: &Arc<ToolRegistry>,
@@ -491,7 +491,7 @@ impl AppBuilder {
         self.init_llm().await
     }
 
-    /// Phase 7: Initialise runtime metering (context manager and cost guard).
+    /// Phase 7: Initialize runtime metering (context manager and cost guard).
     fn init_metering(
         &self,
     ) -> (

--- a/src/app.rs
+++ b/src/app.rs
@@ -701,3 +701,61 @@ impl RuntimeSideEffects {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_side_effects_new_all_none_does_not_panic() {
+        let _ = RuntimeSideEffects::new(None, None, None, false);
+    }
+
+    #[tokio::test]
+    async fn runtime_side_effects_start_no_ops_when_nothing_configured() {
+        let se = RuntimeSideEffects::new(None, None, None, false);
+        // start() returns () — the test passes if it does not panic.
+        se.start();
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn build_components_returns_without_activating_side_effects() -> anyhow::Result<()> {
+        use crate::config::Config;
+        use crate::db::Database;
+        use crate::db::libsql::LibSqlBackend;
+        use crate::llm::SessionConfig;
+        use crate::testing::StubLlm;
+
+        let temp_dir = tempfile::tempdir()?;
+        let db_path = temp_dir.path().join("app-builder-test.db");
+        let backend = LibSqlBackend::new_local(&db_path).await?;
+        backend.run_migrations().await?;
+        let db: Arc<dyn Database> = Arc::new(backend);
+
+        let skills_dir = temp_dir.path().join("skills");
+        let installed_skills_dir = temp_dir.path().join("installed_skills");
+        tokio::fs::create_dir_all(&skills_dir).await?;
+        tokio::fs::create_dir_all(&installed_skills_dir).await?;
+
+        let config = Config::for_testing(db_path, skills_dir, installed_skills_dir).await?;
+        let session = Arc::new(SessionManager::new(SessionConfig::default()));
+        let log_broadcaster = Arc::new(LogBroadcaster::new());
+        let llm: Arc<dyn LlmProvider> = Arc::new(StubLlm::new("ok"));
+
+        let mut builder = AppBuilder::new(
+            config,
+            AppBuilderFlags::default(),
+            None,
+            session,
+            log_broadcaster,
+        );
+        builder.with_database(db);
+        builder.with_llm(llm);
+
+        let (components, _side_effects) = builder.build_components().await?;
+        assert!(components.tools.count() > 0);
+
+        Ok(())
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,6 +88,12 @@ pub struct RuntimeSideEffects {
 /// Join handles for deferred runtime side effects.
 pub struct RuntimeSideEffectsHandle {
     workspace_bootstrap: Option<tokio::task::JoinHandle<()>>,
+    /// Intentionally detached cleanup work.
+    ///
+    /// The leading underscore marks that stale job cleanup is fire-and-forget:
+    /// `wait_until_bootstrapped()` only awaits `workspace_bootstrap`, because
+    /// callers need a fully initialized workspace before continuing but do not
+    /// need to block on background cleanup.
     _cleanup: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -752,6 +758,7 @@ mod tests {
         testing::StubLlm,
     };
     use anyhow::Context;
+    use rstest::{fixture, rstest};
 
     #[cfg(feature = "libsql")]
     use crate::db::libsql::LibSqlBackend;
@@ -788,6 +795,7 @@ mod tests {
     }
 
     #[cfg(feature = "libsql")]
+    #[fixture]
     async fn two_phase_fixture() -> anyhow::Result<(AppBuilder, PathBuf, tempfile::TempDir)> {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("app-builder-test.db");
@@ -829,9 +837,12 @@ mod tests {
     }
 
     #[cfg(feature = "libsql")]
+    #[rstest]
     #[tokio::test]
-    async fn build_components_returns_without_activating_side_effects() -> anyhow::Result<()> {
-        let (builder, workspace_import_dir, _temp_dir) = two_phase_fixture().await?;
+    async fn build_components_returns_without_activating_side_effects(
+        #[future] two_phase_fixture: anyhow::Result<(AppBuilder, PathBuf, tempfile::TempDir)>,
+    ) -> anyhow::Result<()> {
+        let (builder, workspace_import_dir, _temp_dir) = two_phase_fixture.await?;
         let (components, side_effects) = builder.build_components().await?;
         assert!(components.tools.count() > 0);
         let workspace = components
@@ -850,9 +861,12 @@ mod tests {
     }
 
     #[cfg(feature = "libsql")]
+    #[rstest]
     #[tokio::test]
-    async fn build_all_waits_for_workspace_bootstrap() -> anyhow::Result<()> {
-        let (builder, _workspace_import_dir, _temp_dir) = two_phase_fixture().await?;
+    async fn build_all_waits_for_workspace_bootstrap(
+        #[future] two_phase_fixture: anyhow::Result<(AppBuilder, PathBuf, tempfile::TempDir)>,
+    ) -> anyhow::Result<()> {
+        let (builder, _workspace_import_dir, _temp_dir) = two_phase_fixture.await?;
         let components = builder.build_all().await?;
         let workspace = components
             .workspace

--- a/src/app.rs
+++ b/src/app.rs
@@ -752,7 +752,6 @@ mod tests {
         testing::StubLlm,
     };
     use anyhow::Context;
-    use tokio::time::{Duration, Instant};
 
     #[cfg(feature = "libsql")]
     use crate::db::libsql::LibSqlBackend;
@@ -785,27 +784,6 @@ mod tests {
             !workspace.exists(crate::workspace::paths::README).await?,
             "build_components() must not run seed_if_empty()"
         );
-        Ok(())
-    }
-
-    async fn wait_for_import_and_seed(
-        workspace: &Arc<Workspace>,
-        timeout_secs: u64,
-    ) -> anyhow::Result<()> {
-        let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-        loop {
-            if workspace.exists("MARKER.md").await?
-                && workspace.exists(crate::workspace::paths::README).await?
-            {
-                break;
-            }
-            if Instant::now() >= deadline {
-                anyhow::bail!(
-                    "RuntimeSideEffects::start() did not import MARKER.md and seed the workspace in time"
-                );
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
         Ok(())
     }
 
@@ -880,7 +858,10 @@ mod tests {
             .workspace
             .as_ref()
             .context("workspace should be constructed during build_all()")?;
-        wait_for_import_and_seed(workspace, 0).await?;
+        assert!(
+            workspace.exists(crate::workspace::paths::README).await?,
+            "build_all() must complete workspace seeding before returning"
+        );
         let marker = workspace.read("MARKER.md").await?;
         assert_eq!(
             marker.content,

--- a/src/app.rs
+++ b/src/app.rs
@@ -472,7 +472,7 @@ impl AppBuilder {
     }
 
     /// Resolves the LLM provider: returns the injected override if present,
-    /// otherwise delegates to `init_llm()`.
+    /// otherwise validates credentials and delegates to `init_llm()`.
     async fn resolve_llm(
         &mut self,
     ) -> Result<
@@ -486,6 +486,8 @@ impl AppBuilder {
         if let Some(llm) = self.llm_override.take() {
             return Ok((llm, None, None));
         }
+        // Validate credentials only when not using an override.
+        self.validate_llm_config()?;
         self.init_llm().await
     }
 
@@ -522,7 +524,7 @@ impl AppBuilder {
     /// along with deferred runtime side effects.
     ///
     /// This method performs pure construction without activating background
-    /// tasks or I/O-heavy operations. Call `side_effects.start().await` to
+    /// tasks or I/O-heavy operations. Call `side_effects.start()` to
     /// activate deferred work (workspace import, seeding, embedding backfill,
     /// stale job cleanup).
     pub async fn build_components(
@@ -530,7 +532,6 @@ impl AppBuilder {
     ) -> Result<(AppComponents, RuntimeSideEffects), anyhow::Error> {
         self.init_database().await?;
         self.init_secrets().await?;
-        self.validate_llm_config()?;
 
         let (llm, cheap_llm, recording_handle) = self.resolve_llm().await?;
         let (safety, tools, embeddings, workspace) = self.init_tools(&llm).await?;
@@ -601,11 +602,11 @@ impl AppBuilder {
     /// runtime side effects.
     ///
     /// This is equivalent to calling `build_components()` followed by
-    /// `side_effects.start().await`. Use `build_components()` directly when
+    /// `side_effects.start()`. Use `build_components()` directly when
     /// you need control over side-effect timing (e.g., in tests).
     pub async fn build_all(self) -> Result<AppComponents, anyhow::Error> {
         let (components, side_effects) = self.build_components().await?;
-        side_effects.start().await;
+        side_effects.start();
         Ok(components)
     }
 }
@@ -629,15 +630,14 @@ impl RuntimeSideEffects {
     /// Start all deferred runtime side effects.
     ///
     /// This method is fire-and-forget; it spawns background tasks and returns
-    /// immediately. Callers need not await unless ordering guarantees are required
-    /// (e.g., ensuring side effects start before accepting requests).
+    /// immediately. Callers need not await.
     ///
     /// Side effects include:
     /// - Stale sandbox job cleanup (via database)
     /// - Workspace import from disk (if `WORKSPACE_IMPORT_DIR` is set)
     /// - Workspace seeding (if workspace is empty)
     /// - Embedding backfill (spawns a background task)
-    pub async fn start(self) {
+    pub fn start(self) {
         // Spawn stale sandbox cleanup task if database is available.
         if let Some(db) = self.db {
             tokio::spawn(async move {
@@ -647,45 +647,47 @@ impl RuntimeSideEffects {
             });
         }
 
-        // Run workspace import, seeding, and embedding backfill if workspace is available.
-        if let Some(ref ws) = self.workspace {
-            // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
-            // This lets Docker images / deployment scripts ship customized workspace
-            // templates that override generic seeds. Only imports files that don't
-            // already exist in the database — never overwrites user edits.
-            if let Some(import_dir) = self.workspace_import_dir {
-                match ws.import_from_directory(&import_dir).await {
-                    Ok(count) if count > 0 => {
-                        tracing::debug!(
-                            "Imported {} workspace file(s) from {}",
-                            count,
-                            import_dir.display()
-                        );
+        // Spawn workspace import, seeding, and embedding backfill if workspace is available.
+        if let Some(ws) = self.workspace {
+            let import_dir = self.workspace_import_dir;
+            let embeddings_available = self.embeddings_available;
+
+            tokio::spawn(async move {
+                // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
+                // This lets Docker images / deployment scripts ship customized workspace
+                // templates that override generic seeds. Only imports files that don't
+                // already exist in the database — never overwrites user edits.
+                if let Some(dir) = import_dir {
+                    match ws.import_from_directory(&dir).await {
+                        Ok(count) if count > 0 => {
+                            tracing::debug!(
+                                "Imported {} workspace file(s) from {}",
+                                count,
+                                dir.display()
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to import workspace files from {}: {}",
+                                dir.display(),
+                                e
+                            );
+                        }
                     }
+                }
+
+                // Seed workspace with default content if empty.
+                match ws.seed_if_empty().await {
                     Ok(_) => {}
                     Err(e) => {
-                        tracing::warn!(
-                            "Failed to import workspace files from {}: {}",
-                            import_dir.display(),
-                            e
-                        );
+                        tracing::warn!("Failed to seed workspace: {}", e);
                     }
                 }
-            }
 
-            // Seed workspace with default content if empty.
-            match ws.seed_if_empty().await {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!("Failed to seed workspace: {}", e);
-                }
-            }
-
-            // Spawn embedding backfill in background if embeddings are configured.
-            if self.embeddings_available {
-                let ws_bg = Arc::clone(ws);
-                tokio::spawn(async move {
-                    match ws_bg.backfill_embeddings().await {
+                // Backfill embeddings in background if embeddings are configured.
+                if embeddings_available {
+                    match ws.backfill_embeddings().await {
                         Ok(count) if count > 0 => {
                             tracing::debug!("Backfilled embeddings for {} chunks", count);
                         }
@@ -694,8 +696,8 @@ impl RuntimeSideEffects {
                             tracing::warn!("Failed to backfill embeddings: {}", e);
                         }
                     }
-                });
-            }
+                }
+            });
         }
     }
 }

--- a/src/boot_screen.rs
+++ b/src/boot_screen.rs
@@ -4,6 +4,15 @@
 //! state: model, database, tool count, enabled features, active channels,
 //! and the gateway URL.
 
+use crate::sandbox::detect::DockerStatus;
+
+const ANSI_BOLD: &str = "\x1b[1m";
+const ANSI_CYAN: &str = "\x1b[36m";
+const ANSI_DIM: &str = "\x1b[90m";
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_YELLOW: &str = "\x1b[33m";
+const ANSI_YELLOW_UNDERLINE: &str = "\x1b[33;4m";
+
 /// All displayable fields for the boot screen.
 pub struct BootInfo {
     pub version: String,
@@ -31,62 +40,70 @@ pub struct BootInfo {
     pub tunnel_provider: Option<String>,
 }
 
-/// Render the boot screen to a string.
-pub fn render_boot_screen(info: &BootInfo) -> String {
-    // ANSI codes matching existing REPL palette
-    let bold = "\x1b[1m";
-    let cyan = "\x1b[36m";
-    let dim = "\x1b[90m";
-    let yellow = "\x1b[33m";
-    let yellow_underline = "\x1b[33;4m";
-    let reset = "\x1b[0m";
+fn border_line() -> String {
+    format!("  {ANSI_DIM}{}{ANSI_RESET}", "\u{2576}".repeat(58))
+}
 
-    let border = format!("  {dim}{}{reset}", "\u{2576}".repeat(58));
-
+fn render_header(info: &BootInfo) -> String {
     let mut output = String::new();
-
     output.push('\n');
-    output.push_str(&border);
+    output.push_str(&border_line());
     output.push('\n');
     output.push('\n');
     output.push_str(&format!(
-        "  {bold}{}{reset} v{}\n",
+        "  {ANSI_BOLD}{}{ANSI_RESET} v{}\n",
         info.agent_name, info.version
     ));
     output.push('\n');
+    output
+}
 
-    // Model line
+fn render_main_rows(info: &BootInfo) -> String {
     let model_display = if let Some(ref cheap) = info.cheap_model {
         format!(
-            "{cyan}{}{reset}  {dim}cheap{reset} {cyan}{}{reset}",
+            "{ANSI_CYAN}{}{ANSI_RESET}  {ANSI_DIM}cheap{ANSI_RESET} {ANSI_CYAN}{}{ANSI_RESET}",
             info.llm_model, cheap
         )
     } else {
-        format!("{cyan}{}{reset}", info.llm_model)
+        format!("{ANSI_CYAN}{}{ANSI_RESET}", info.llm_model)
     };
-    output.push_str(&format!(
-        "  {dim}model{reset}     {model_display}  {dim}via {}{reset}\n",
-        info.llm_backend
-    ));
-
-    // Database line
     let db_status = if info.db_connected {
         "connected"
     } else {
         "none"
     };
-    output.push_str(&format!(
-        "  {dim}database{reset}  {cyan}{}{reset} {dim}({db_status}){reset}\n",
-        info.db_backend
-    ));
 
-    // Tools line
-    output.push_str(&format!(
-        "  {dim}tools{reset}     {cyan}{}{reset} {dim}registered{reset}\n",
-        info.tool_count
-    ));
+    [
+        format!(
+            "  {ANSI_DIM}model{ANSI_RESET}     {model_display}  {ANSI_DIM}via {}{ANSI_RESET}\n",
+            info.llm_backend
+        ),
+        format!(
+            "  {ANSI_DIM}database{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET} {ANSI_DIM}({db_status}){ANSI_RESET}\n",
+            info.db_backend
+        ),
+        format!(
+            "  {ANSI_DIM}tools{ANSI_RESET}     {ANSI_CYAN}{}{ANSI_RESET} {ANSI_DIM}registered{ANSI_RESET}\n",
+            info.tool_count
+        ),
+    ]
+    .concat()
+}
 
-    // Features line
+fn docker_feature_label(status: DockerStatus) -> Option<String> {
+    match status {
+        DockerStatus::Available => Some("sandbox".to_string()),
+        DockerStatus::NotInstalled => Some(format!(
+            "{ANSI_YELLOW}sandbox (docker not installed){ANSI_RESET}"
+        )),
+        DockerStatus::NotRunning => Some(format!(
+            "{ANSI_YELLOW}sandbox (docker not running){ANSI_RESET}"
+        )),
+        DockerStatus::Disabled => None,
+    }
+}
+
+fn render_features_row(info: &BootInfo) -> Option<String> {
     let mut features = Vec::new();
     if info.embeddings_enabled {
         if let Some(ref provider) = info.embeddings_provider {
@@ -99,19 +116,8 @@ pub fn render_boot_screen(info: &BootInfo) -> String {
         let mins = info.heartbeat_interval_secs / 60;
         features.push(format!("heartbeat ({mins}m)"));
     }
-    match info.docker_status {
-        crate::sandbox::detect::DockerStatus::Available => {
-            features.push("sandbox".to_string());
-        }
-        crate::sandbox::detect::DockerStatus::NotInstalled => {
-            features.push(format!("{yellow}sandbox (docker not installed){reset}"));
-        }
-        crate::sandbox::detect::DockerStatus::NotRunning => {
-            features.push(format!("{yellow}sandbox (docker not running){reset}"));
-        }
-        crate::sandbox::detect::DockerStatus::Disabled => {
-            // Don't show sandbox when disabled
-        }
+    if let Some(label) = docker_feature_label(info.docker_status) {
+        features.push(label);
     }
     if info.claude_code_enabled {
         features.push("claude-code".to_string());
@@ -122,48 +128,72 @@ pub fn render_boot_screen(info: &BootInfo) -> String {
     if info.skills_enabled {
         features.push("skills".to_string());
     }
-    if !features.is_empty() {
-        output.push_str(&format!(
-            "  {dim}features{reset}  {cyan}{}{reset}\n",
+
+    (!features.is_empty()).then(|| {
+        format!(
+            "  {ANSI_DIM}features{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET}\n",
             features.join("  ")
-        ));
-    }
+        )
+    })
+}
 
-    // Channels line
-    if !info.channels.is_empty() {
-        output.push_str(&format!(
-            "  {dim}channels{reset}  {cyan}{}{reset}\n",
+fn render_channels_row(info: &BootInfo) -> Option<String> {
+    (!info.channels.is_empty()).then(|| {
+        format!(
+            "  {ANSI_DIM}channels{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET}\n",
             info.channels.join("  ")
-        ));
-    }
+        )
+    })
+}
 
-    // Gateway URL (highlighted)
+fn render_urls_block(info: &BootInfo) -> String {
+    let mut output = String::new();
+
     if let Some(ref url) = info.gateway_url {
         output.push('\n');
         output.push_str(&format!(
-            "  {dim}gateway{reset}   {yellow_underline}{url}{reset}\n"
+            "  {ANSI_DIM}gateway{ANSI_RESET}   {ANSI_YELLOW_UNDERLINE}{url}{ANSI_RESET}\n"
         ));
     }
 
-    // Tunnel URL
     if let Some(ref url) = info.tunnel_url {
         let provider_tag = info
             .tunnel_provider
             .as_deref()
-            .map(|p| format!(" {dim}({p}){reset}"))
+            .map(|p| format!(" {ANSI_DIM}({p}){ANSI_RESET}"))
             .unwrap_or_default();
         output.push_str(&format!(
-            "  {dim}tunnel{reset}    {yellow_underline}{url}{reset}{provider_tag}\n"
+            "  {ANSI_DIM}tunnel{ANSI_RESET}    {ANSI_YELLOW_UNDERLINE}{url}{ANSI_RESET}{provider_tag}\n"
         ));
     }
 
+    output
+}
+
+fn render_footer() -> String {
+    let mut output = String::new();
     output.push('\n');
-    output.push_str(&border);
+    output.push_str(&border_line());
     output.push('\n');
     output.push('\n');
     output.push_str("  /help for commands, /quit to exit\n");
     output.push('\n');
+    output
+}
 
+/// Render the boot screen to a string.
+pub fn render_boot_screen(info: &BootInfo) -> String {
+    let mut output = String::new();
+    output.push_str(&render_header(info));
+    output.push_str(&render_main_rows(info));
+    if let Some(features_row) = render_features_row(info) {
+        output.push_str(&features_row);
+    }
+    if let Some(channels_row) = render_channels_row(info) {
+        output.push_str(&channels_row);
+    }
+    output.push_str(&render_urls_block(info));
+    output.push_str(&render_footer());
     output
 }
 
@@ -175,8 +205,8 @@ pub fn print_boot_screen(info: &BootInfo) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sandbox::detect::DockerStatus;
     use insta::assert_snapshot;
+    use rstest::rstest;
 
     fn full_boot_info() -> BootInfo {
         BootInfo {
@@ -260,25 +290,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_render_boot_screen_full_snapshot() {
-        let info = full_boot_info();
+    #[rstest]
+    #[case::full("render_boot_screen_full_snapshot", full_boot_info())]
+    #[case::minimal("render_boot_screen_minimal_snapshot", minimal_boot_info())]
+    #[case::no_features("render_boot_screen_no_features_snapshot", no_features_boot_info())]
+    fn test_render_boot_screen_snapshot(#[case] snapshot_name: &str, #[case] info: BootInfo) {
         let output = render_boot_screen(&info);
-        assert_snapshot!(&output);
-    }
-
-    #[test]
-    fn test_render_boot_screen_minimal_snapshot() {
-        let info = minimal_boot_info();
-        let output = render_boot_screen(&info);
-        assert_snapshot!(&output);
-    }
-
-    #[test]
-    fn test_render_boot_screen_no_features_snapshot() {
-        let info = no_features_boot_info();
-        let output = render_boot_screen(&info);
-        assert_snapshot!(&output);
+        assert_snapshot!(snapshot_name, &output);
     }
 
     #[test]
@@ -297,21 +315,12 @@ mod tests {
         assert_snapshot!(&output);
     }
 
-    #[test]
-    fn test_print_boot_screen_full() {
+    #[rstest]
+    #[case::full(full_boot_info())]
+    #[case::minimal(minimal_boot_info())]
+    #[case::no_features(no_features_boot_info())]
+    fn test_print_boot_screen(#[case] info: BootInfo) {
         // Should not panic
-        print_boot_screen(&full_boot_info());
-    }
-
-    #[test]
-    fn test_print_boot_screen_minimal() {
-        // Should not panic
-        print_boot_screen(&minimal_boot_info());
-    }
-
-    #[test]
-    fn test_print_boot_screen_no_features() {
-        // Should not panic
-        print_boot_screen(&no_features_boot_info());
+        print_boot_screen(&info);
     }
 }

--- a/src/boot_screen.rs
+++ b/src/boot_screen.rs
@@ -31,8 +31,8 @@ pub struct BootInfo {
     pub tunnel_provider: Option<String>,
 }
 
-/// Print the boot screen to stdout.
-pub fn print_boot_screen(info: &BootInfo) {
+/// Render the boot screen to a string.
+pub fn render_boot_screen(info: &BootInfo) -> String {
     // ANSI codes matching existing REPL palette
     let bold = "\x1b[1m";
     let cyan = "\x1b[36m";
@@ -43,11 +43,17 @@ pub fn print_boot_screen(info: &BootInfo) {
 
     let border = format!("  {dim}{}{reset}", "\u{2576}".repeat(58));
 
-    println!();
-    println!("{border}");
-    println!();
-    println!("  {bold}{}{reset} v{}", info.agent_name, info.version);
-    println!();
+    let mut output = String::new();
+
+    output.push('\n');
+    output.push_str(&border);
+    output.push('\n');
+    output.push('\n');
+    output.push_str(&format!(
+        "  {bold}{}{reset} v{}\n",
+        info.agent_name, info.version
+    ));
+    output.push('\n');
 
     // Model line
     let model_display = if let Some(ref cheap) = info.cheap_model {
@@ -58,10 +64,10 @@ pub fn print_boot_screen(info: &BootInfo) {
     } else {
         format!("{cyan}{}{reset}", info.llm_model)
     };
-    println!(
-        "  {dim}model{reset}     {model_display}  {dim}via {}{reset}",
+    output.push_str(&format!(
+        "  {dim}model{reset}     {model_display}  {dim}via {}{reset}\n",
         info.llm_backend
-    );
+    ));
 
     // Database line
     let db_status = if info.db_connected {
@@ -69,16 +75,16 @@ pub fn print_boot_screen(info: &BootInfo) {
     } else {
         "none"
     };
-    println!(
-        "  {dim}database{reset}  {cyan}{}{reset} {dim}({db_status}){reset}",
+    output.push_str(&format!(
+        "  {dim}database{reset}  {cyan}{}{reset} {dim}({db_status}){reset}\n",
         info.db_backend
-    );
+    ));
 
     // Tools line
-    println!(
-        "  {dim}tools{reset}     {cyan}{}{reset} {dim}registered{reset}",
+    output.push_str(&format!(
+        "  {dim}tools{reset}     {cyan}{}{reset} {dim}registered{reset}\n",
         info.tool_count
-    );
+    ));
 
     // Features line
     let mut features = Vec::new();
@@ -117,24 +123,26 @@ pub fn print_boot_screen(info: &BootInfo) {
         features.push("skills".to_string());
     }
     if !features.is_empty() {
-        println!(
-            "  {dim}features{reset}  {cyan}{}{reset}",
+        output.push_str(&format!(
+            "  {dim}features{reset}  {cyan}{}{reset}\n",
             features.join("  ")
-        );
+        ));
     }
 
     // Channels line
     if !info.channels.is_empty() {
-        println!(
-            "  {dim}channels{reset}  {cyan}{}{reset}",
+        output.push_str(&format!(
+            "  {dim}channels{reset}  {cyan}{}{reset}\n",
             info.channels.join("  ")
-        );
+        ));
     }
 
     // Gateway URL (highlighted)
     if let Some(ref url) = info.gateway_url {
-        println!();
-        println!("  {dim}gateway{reset}   {yellow_underline}{url}{reset}");
+        output.push('\n');
+        output.push_str(&format!(
+            "  {dim}gateway{reset}   {yellow_underline}{url}{reset}\n"
+        ));
     }
 
     // Tunnel URL
@@ -144,24 +152,34 @@ pub fn print_boot_screen(info: &BootInfo) {
             .as_deref()
             .map(|p| format!(" {dim}({p}){reset}"))
             .unwrap_or_default();
-        println!("  {dim}tunnel{reset}    {yellow_underline}{url}{reset}{provider_tag}");
+        output.push_str(&format!(
+            "  {dim}tunnel{reset}    {yellow_underline}{url}{reset}{provider_tag}\n"
+        ));
     }
 
-    println!();
-    println!("{border}");
-    println!();
-    println!("  /help for commands, /quit to exit");
-    println!();
+    output.push('\n');
+    output.push_str(&border);
+    output.push('\n');
+    output.push('\n');
+    output.push_str("  /help for commands, /quit to exit\n");
+    output.push('\n');
+
+    output
+}
+
+/// Print the boot screen to stdout.
+pub fn print_boot_screen(info: &BootInfo) {
+    print!("{}", render_boot_screen(info));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sandbox::detect::DockerStatus;
+    use insta::assert_snapshot;
 
-    #[test]
-    fn test_print_boot_screen_full() {
-        let info = BootInfo {
+    fn full_boot_info() -> BootInfo {
+        BootInfo {
             version: "0.2.0".to_string(),
             agent_name: "ironclaw".to_string(),
             llm_backend: "nearai".to_string(),
@@ -187,14 +205,11 @@ mod tests {
             ],
             tunnel_url: Some("https://abc123.ngrok.io".to_string()),
             tunnel_provider: Some("ngrok".to_string()),
-        };
-        // Should not panic
-        print_boot_screen(&info);
+        }
     }
 
-    #[test]
-    fn test_print_boot_screen_minimal() {
-        let info = BootInfo {
+    fn minimal_boot_info() -> BootInfo {
+        BootInfo {
             version: "0.2.0".to_string(),
             agent_name: "ironclaw".to_string(),
             llm_backend: "nearai".to_string(),
@@ -216,14 +231,11 @@ mod tests {
             channels: vec![],
             tunnel_url: None,
             tunnel_provider: None,
-        };
-        // Should not panic
-        print_boot_screen(&info);
+        }
     }
 
-    #[test]
-    fn test_print_boot_screen_no_features() {
-        let info = BootInfo {
+    fn no_features_boot_info() -> BootInfo {
+        BootInfo {
             version: "0.1.0".to_string(),
             agent_name: "test".to_string(),
             llm_backend: "openai".to_string(),
@@ -245,8 +257,61 @@ mod tests {
             channels: vec!["repl".to_string()],
             tunnel_url: None,
             tunnel_provider: None,
-        };
+        }
+    }
+
+    #[test]
+    fn test_render_boot_screen_full_snapshot() {
+        let info = full_boot_info();
+        let output = render_boot_screen(&info);
+        assert_snapshot!(&output);
+    }
+
+    #[test]
+    fn test_render_boot_screen_minimal_snapshot() {
+        let info = minimal_boot_info();
+        let output = render_boot_screen(&info);
+        assert_snapshot!(&output);
+    }
+
+    #[test]
+    fn test_render_boot_screen_no_features_snapshot() {
+        let info = no_features_boot_info();
+        let output = render_boot_screen(&info);
+        assert_snapshot!(&output);
+    }
+
+    #[test]
+    fn test_render_boot_screen_docker_not_installed() {
+        let mut info = full_boot_info();
+        info.docker_status = DockerStatus::NotInstalled;
+        let output = render_boot_screen(&info);
+        assert_snapshot!(&output);
+    }
+
+    #[test]
+    fn test_render_boot_screen_docker_not_running() {
+        let mut info = full_boot_info();
+        info.docker_status = DockerStatus::NotRunning;
+        let output = render_boot_screen(&info);
+        assert_snapshot!(&output);
+    }
+
+    #[test]
+    fn test_print_boot_screen_full() {
         // Should not panic
-        print_boot_screen(&info);
+        print_boot_screen(&full_boot_info());
+    }
+
+    #[test]
+    fn test_print_boot_screen_minimal() {
+        // Should not panic
+        print_boot_screen(&minimal_boot_info());
+    }
+
+    #[test]
+    fn test_print_boot_screen_no_features() {
+        // Should not panic
+        print_boot_screen(&no_features_boot_info());
     }
 }

--- a/src/boot_screen.rs
+++ b/src/boot_screen.rs
@@ -6,13 +6,6 @@
 
 use crate::sandbox::detect::DockerStatus;
 
-const ANSI_BOLD: &str = "\x1b[1m";
-const ANSI_CYAN: &str = "\x1b[36m";
-const ANSI_DIM: &str = "\x1b[90m";
-const ANSI_RESET: &str = "\x1b[0m";
-const ANSI_YELLOW: &str = "\x1b[33m";
-const ANSI_YELLOW_UNDERLINE: &str = "\x1b[33;4m";
-
 /// All displayable fields for the boot screen.
 pub struct BootInfo {
     pub version: String,
@@ -40,70 +33,46 @@ pub struct BootInfo {
     pub tunnel_provider: Option<String>,
 }
 
-fn border_line() -> String {
-    format!("  {ANSI_DIM}{}{ANSI_RESET}", "\u{2576}".repeat(58))
+struct Palette<'a> {
+    cyan: &'a str,
+    dim: &'a str,
+    yellow: &'a str,
+    yellow_underline: &'a str,
+    reset: &'a str,
 }
 
-fn render_header(info: &BootInfo) -> String {
-    let mut output = String::new();
-    output.push('\n');
-    output.push_str(&border_line());
-    output.push('\n');
-    output.push('\n');
-    output.push_str(&format!(
-        "  {ANSI_BOLD}{}{ANSI_RESET} v{}\n",
-        info.agent_name, info.version
-    ));
-    output.push('\n');
-    output
-}
-
-fn render_main_rows(info: &BootInfo) -> String {
+fn render_model_line(info: &BootInfo, p: &Palette<'_>) -> String {
     let model_display = if let Some(ref cheap) = info.cheap_model {
         format!(
-            "{ANSI_CYAN}{}{ANSI_RESET}  {ANSI_DIM}cheap{ANSI_RESET} {ANSI_CYAN}{}{ANSI_RESET}",
-            info.llm_model, cheap
+            "{cyan}{llm}{reset}  {dim}cheap{reset} {cyan}{cheap}{reset}",
+            cyan = p.cyan,
+            dim = p.dim,
+            reset = p.reset,
+            llm = info.llm_model,
         )
     } else {
-        format!("{ANSI_CYAN}{}{ANSI_RESET}", info.llm_model)
+        format!("{}{}{}", p.cyan, info.llm_model, p.reset)
     };
-    let db_status = if info.db_connected {
-        "connected"
-    } else {
-        "none"
-    };
-
-    [
-        format!(
-            "  {ANSI_DIM}model{ANSI_RESET}     {model_display}  {ANSI_DIM}via {}{ANSI_RESET}\n",
-            info.llm_backend
-        ),
-        format!(
-            "  {ANSI_DIM}database{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET} {ANSI_DIM}({db_status}){ANSI_RESET}\n",
-            info.db_backend
-        ),
-        format!(
-            "  {ANSI_DIM}tools{ANSI_RESET}     {ANSI_CYAN}{}{ANSI_RESET} {ANSI_DIM}registered{ANSI_RESET}\n",
-            info.tool_count
-        ),
-    ]
-    .concat()
+    format!(
+        "  {dim}model{reset}     {model_display}  {dim}via {backend}{reset}\n",
+        dim = p.dim,
+        reset = p.reset,
+        backend = info.llm_backend,
+    )
 }
 
-fn docker_feature_label(status: DockerStatus) -> Option<String> {
+fn format_docker_feature(status: &DockerStatus, yellow: &str, reset: &str) -> Option<String> {
     match status {
         DockerStatus::Available => Some("sandbox".to_string()),
-        DockerStatus::NotInstalled => Some(format!(
-            "{ANSI_YELLOW}sandbox (docker not installed){ANSI_RESET}"
-        )),
-        DockerStatus::NotRunning => Some(format!(
-            "{ANSI_YELLOW}sandbox (docker not running){ANSI_RESET}"
-        )),
+        DockerStatus::NotInstalled => {
+            Some(format!("{yellow}sandbox (docker not installed){reset}"))
+        }
+        DockerStatus::NotRunning => Some(format!("{yellow}sandbox (docker not running){reset}")),
         DockerStatus::Disabled => None,
     }
 }
 
-fn render_features_row(info: &BootInfo) -> Option<String> {
+fn collect_features(info: &BootInfo, yellow: &str, reset: &str) -> Vec<String> {
     let mut features = Vec::new();
     if info.embeddings_enabled {
         if let Some(ref provider) = info.embeddings_provider {
@@ -116,7 +85,7 @@ fn render_features_row(info: &BootInfo) -> Option<String> {
         let mins = info.heartbeat_interval_secs / 60;
         features.push(format!("heartbeat ({mins}m)"));
     }
-    if let Some(label) = docker_feature_label(info.docker_status) {
+    if let Some(label) = format_docker_feature(&info.docker_status, yellow, reset) {
         features.push(label);
     }
     if info.claude_code_enabled {
@@ -128,72 +97,98 @@ fn render_features_row(info: &BootInfo) -> Option<String> {
     if info.skills_enabled {
         features.push("skills".to_string());
     }
-
-    (!features.is_empty()).then(|| {
-        format!(
-            "  {ANSI_DIM}features{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET}\n",
-            features.join("  ")
-        )
-    })
+    features
 }
 
-fn render_channels_row(info: &BootInfo) -> Option<String> {
-    (!info.channels.is_empty()).then(|| {
-        format!(
-            "  {ANSI_DIM}channels{ANSI_RESET}  {ANSI_CYAN}{}{ANSI_RESET}\n",
-            info.channels.join("  ")
-        )
-    })
-}
-
-fn render_urls_block(info: &BootInfo) -> String {
-    let mut output = String::new();
-
+fn render_footer_urls(info: &BootInfo, p: &Palette<'_>) -> String {
+    let mut out = String::new();
     if let Some(ref url) = info.gateway_url {
-        output.push('\n');
-        output.push_str(&format!(
-            "  {ANSI_DIM}gateway{ANSI_RESET}   {ANSI_YELLOW_UNDERLINE}{url}{ANSI_RESET}\n"
+        out.push('\n');
+        out.push_str(&format!(
+            "  {dim}gateway{reset}   {yu}{url}{reset}\n",
+            dim = p.dim,
+            reset = p.reset,
+            yu = p.yellow_underline,
         ));
     }
-
     if let Some(ref url) = info.tunnel_url {
         let provider_tag = info
             .tunnel_provider
             .as_deref()
-            .map(|p| format!(" {ANSI_DIM}({p}){ANSI_RESET}"))
+            .map(|name| format!(" {dim}({name}){reset}", dim = p.dim, reset = p.reset))
             .unwrap_or_default();
-        output.push_str(&format!(
-            "  {ANSI_DIM}tunnel{ANSI_RESET}    {ANSI_YELLOW_UNDERLINE}{url}{ANSI_RESET}{provider_tag}\n"
+        out.push_str(&format!(
+            "  {dim}tunnel{reset}    {yu}{url}{reset}{provider_tag}\n",
+            dim = p.dim,
+            reset = p.reset,
+            yu = p.yellow_underline,
         ));
     }
-
-    output
-}
-
-fn render_footer() -> String {
-    let mut output = String::new();
-    output.push('\n');
-    output.push_str(&border_line());
-    output.push('\n');
-    output.push('\n');
-    output.push_str("  /help for commands, /quit to exit\n");
-    output.push('\n');
-    output
+    out
 }
 
 /// Render the boot screen to a string.
 pub fn render_boot_screen(info: &BootInfo) -> String {
+    let bold = "\x1b[1m";
+    let cyan = "\x1b[36m";
+    let dim = "\x1b[90m";
+    let yellow = "\x1b[33m";
+    let yellow_underline = "\x1b[33;4m";
+    let reset = "\x1b[0m";
+
+    let palette = Palette {
+        cyan,
+        dim,
+        yellow,
+        yellow_underline,
+        reset,
+    };
+    let border = format!("  {dim}{}{reset}", "\u{2576}".repeat(58));
+    let db_status = if info.db_connected {
+        "connected"
+    } else {
+        "none"
+    };
+    let features = collect_features(info, palette.yellow, palette.reset);
+
     let mut output = String::new();
-    output.push_str(&render_header(info));
-    output.push_str(&render_main_rows(info));
-    if let Some(features_row) = render_features_row(info) {
-        output.push_str(&features_row);
+    output.push('\n');
+    output.push_str(&border);
+    output.push('\n');
+    output.push('\n');
+    output.push_str(&format!(
+        "  {bold}{}{reset} v{}\n",
+        info.agent_name, info.version
+    ));
+    output.push('\n');
+    output.push_str(&render_model_line(info, &palette));
+    output.push_str(&format!(
+        "  {dim}database{reset}  {cyan}{}{reset} {dim}({db_status}){reset}\n",
+        info.db_backend
+    ));
+    output.push_str(&format!(
+        "  {dim}tools{reset}     {cyan}{}{reset} {dim}registered{reset}\n",
+        info.tool_count
+    ));
+    if !features.is_empty() {
+        output.push_str(&format!(
+            "  {dim}features{reset}  {cyan}{}{reset}\n",
+            features.join("  ")
+        ));
     }
-    if let Some(channels_row) = render_channels_row(info) {
-        output.push_str(&channels_row);
+    if !info.channels.is_empty() {
+        output.push_str(&format!(
+            "  {dim}channels{reset}  {cyan}{}{reset}\n",
+            info.channels.join("  ")
+        ));
     }
-    output.push_str(&render_urls_block(info));
-    output.push_str(&render_footer());
+    output.push_str(&render_footer_urls(info, &palette));
+    output.push('\n');
+    output.push_str(&border);
+    output.push('\n');
+    output.push('\n');
+    output.push_str("  /help for commands, /quit to exit\n");
+    output.push('\n');
     output
 }
 

--- a/src/boot_screen.rs
+++ b/src/boot_screen.rs
@@ -238,16 +238,19 @@ mod tests {
         }
     }
 
-    fn minimal_boot_info() -> BootInfo {
+    /// Provides a BootInfo with all optional feature fields set to their
+    /// "disabled / none" state. Individual test helpers override only the
+    /// fields relevant to their scenario.
+    fn base_disabled_boot_info() -> BootInfo {
         BootInfo {
-            version: "0.2.0".to_string(),
-            agent_name: "ironclaw".to_string(),
-            llm_backend: "nearai".to_string(),
-            llm_model: "gpt-4o".to_string(),
+            version: String::new(),
+            agent_name: String::new(),
+            llm_backend: String::new(),
+            llm_model: String::new(),
             cheap_model: None,
-            db_backend: "none".to_string(),
+            db_backend: String::new(),
             db_connected: false,
-            tool_count: 5,
+            tool_count: 0,
             gateway_url: None,
             embeddings_enabled: false,
             embeddings_provider: None,
@@ -264,29 +267,29 @@ mod tests {
         }
     }
 
+    fn minimal_boot_info() -> BootInfo {
+        BootInfo {
+            version: "0.2.0".to_string(),
+            agent_name: "ironclaw".to_string(),
+            llm_backend: "nearai".to_string(),
+            llm_model: "gpt-4o".to_string(),
+            db_backend: "none".to_string(),
+            tool_count: 5,
+            ..base_disabled_boot_info()
+        }
+    }
+
     fn no_features_boot_info() -> BootInfo {
         BootInfo {
             version: "0.1.0".to_string(),
             agent_name: "test".to_string(),
             llm_backend: "openai".to_string(),
             llm_model: "gpt-4o".to_string(),
-            cheap_model: None,
             db_backend: "postgres".to_string(),
             db_connected: true,
             tool_count: 10,
-            gateway_url: None,
-            embeddings_enabled: false,
-            embeddings_provider: None,
-            heartbeat_enabled: false,
-            heartbeat_interval_secs: 0,
-            sandbox_enabled: false,
-            docker_status: DockerStatus::Disabled,
-            claude_code_enabled: false,
-            routines_enabled: false,
-            skills_enabled: false,
             channels: vec!["repl".to_string()],
-            tunnel_url: None,
-            tunnel_provider: None,
+            ..base_disabled_boot_info()
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -920,7 +920,7 @@ async fn run_onboard_subcommand(
     #[cfg(not(any(feature = "postgres", feature = "libsql")))]
     {
         let _ = (skip_auth, channels_only, provider_only, quick);
-        eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
+        anyhow::bail!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
     }
     Ok(())
 }
@@ -1020,8 +1020,16 @@ async fn setup_gateway_channel(
                 let mut rx = tx.subscribe();
                 let gw_state = Arc::clone(gw.state());
                 tokio::spawn(async move {
-                    while let Ok((_job_id, event)) = rx.recv().await {
-                        gw_state.sse.broadcast(event);
+                    loop {
+                        match rx.recv().await {
+                            Ok((_job_id, event)) => {
+                                gw_state.sse.broadcast(event);
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                                tracing::warn!(skipped, "Gateway job-event stream lagged");
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        }
                     }
                 });
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,12 +160,13 @@ struct HttpChannelResult {
     http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>>,
 }
 
-async fn setup_repl_channel(
-    cli: &Cli,
-    config: &Config,
-    channels: &ChannelManager,
-    channel_names: &mut Vec<String>,
-) {
+/// Registration sinks shared across channel-setup helpers.
+struct ChannelRegistrar<'a> {
+    channels: &'a ChannelManager,
+    channel_names: &'a mut Vec<String>,
+    webhook_routes: &'a mut Vec<axum::Router>,
+}
+async fn setup_repl_channel(cli: &Cli, config: &Config, reg: &mut ChannelRegistrar<'_>) {
     let repl_channel = if let Some(ref msg) = cli.message {
         Some(ReplChannel::with_message(msg.clone()))
     } else if config.channels.cli.enabled {
@@ -176,11 +177,11 @@ async fn setup_repl_channel(
         None
     };
     let Some(repl) = repl_channel else { return };
-    channels.add(Box::new(repl)).await;
+    reg.channels.add(Box::new(repl)).await;
     if cli.message.is_some() {
         tracing::debug!("Single message mode");
     } else {
-        channel_names.push("repl".to_string());
+        reg.channel_names.push("repl".to_string());
         tracing::debug!("REPL mode enabled");
     }
 }
@@ -188,9 +189,7 @@ async fn setup_repl_channel(
 async fn setup_wasm_channels_infra(
     config: &Config,
     components: &ironclaw::app::AppComponents,
-    channels: &ChannelManager,
-    channel_names: &mut Vec<String>,
-    webhook_routes: &mut Vec<axum::Router>,
+    reg: &mut ChannelRegistrar<'_>,
 ) -> WasmInfraResult {
     let empty = WasmInfraResult {
         channel_names: vec![],
@@ -219,11 +218,11 @@ async fn setup_wasm_channels_infra(
     let mut wasm_channel_names = Vec::new();
     for (name, channel) in result.channels {
         wasm_channel_names.push(name.clone());
-        channel_names.push(name);
-        channels.add(channel).await;
+        reg.channel_names.push(name);
+        reg.channels.add(channel).await;
     }
     if let Some(routes) = result.webhook_routes {
-        webhook_routes.push(routes);
+        reg.webhook_routes.push(routes);
     }
     WasmInfraResult {
         channel_names: wasm_channel_names,
@@ -235,8 +234,7 @@ async fn setup_wasm_channels_infra(
 async fn setup_signal_channel(
     cli: &Cli,
     config: &Config,
-    channels: &ChannelManager,
-    channel_names: &mut Vec<String>,
+    reg: &mut ChannelRegistrar<'_>,
 ) -> anyhow::Result<()> {
     if cli.cli_only {
         return Ok(());
@@ -245,8 +243,8 @@ async fn setup_signal_channel(
         return Ok(());
     };
     let signal_channel = SignalChannel::new(signal_config.clone())?;
-    channel_names.push("signal".to_string());
-    channels.add(Box::new(signal_channel)).await;
+    reg.channel_names.push("signal".to_string());
+    reg.channels.add(Box::new(signal_channel)).await;
     let safe_url = SignalChannel::redact_url(&signal_config.http_url);
     tracing::debug!(url = %safe_url, "Signal channel enabled");
     if signal_config.allow_from.is_empty() {
@@ -258,9 +256,7 @@ async fn setup_signal_channel(
 async fn setup_http_channel(
     cli: &Cli,
     config: &Config,
-    channels: &ChannelManager,
-    channel_names: &mut Vec<String>,
-    webhook_routes: &mut Vec<axum::Router>,
+    reg: &mut ChannelRegistrar<'_>,
 ) -> HttpChannelResult {
     let none_result = HttpChannelResult {
         webhook_server_addr: None,
@@ -276,15 +272,15 @@ async fn setup_http_channel(
     let http_channel = HttpChannel::new(http_config.clone());
     #[cfg(unix)]
     let http_channel_state = Some(http_channel.shared_state());
-    webhook_routes.push(http_channel.routes());
+    reg.webhook_routes.push(http_channel.routes());
     let (host, port) = http_channel.addr();
     let webhook_server_addr = Some(
         format!("{}:{}", host, port)
             .parse()
             .expect("HttpConfig host:port must be a valid SocketAddr"),
     );
-    channel_names.push("http".to_string());
-    channels.add(Box::new(http_channel)).await;
+    reg.channel_names.push("http".to_string());
+    reg.channels.add(Box::new(http_channel)).await;
     tracing::debug!(
         "HTTP channel enabled on {}:{}",
         http_config.host,
@@ -328,28 +324,24 @@ async fn setup_channel_infrastructure(
 ) -> anyhow::Result<ChannelInfrastructure> {
     let mut channel_names: Vec<String> = Vec::new();
     let mut webhook_routes: Vec<axum::Router> = Vec::new();
-
-    setup_repl_channel(cli, config, channels, &mut channel_names).await;
-
-    let wasm = setup_wasm_channels_infra(
-        config,
-        components,
+    let mut reg = ChannelRegistrar {
         channels,
-        &mut channel_names,
-        &mut webhook_routes,
-    )
-    .await;
+        channel_names: &mut channel_names,
+        webhook_routes: &mut webhook_routes,
+    };
 
-    setup_signal_channel(cli, config, channels, &mut channel_names).await?;
+    setup_repl_channel(cli, config, &mut reg).await;
 
-    let http = setup_http_channel(
-        cli,
-        config,
-        channels,
-        &mut channel_names,
-        &mut webhook_routes,
-    )
-    .await;
+    let wasm = setup_wasm_channels_infra(config, components, &mut reg).await;
+
+    setup_signal_channel(cli, config, &mut reg).await?;
+
+    let http = setup_http_channel(cli, config, &mut reg).await;
+
+    // `reg` is dropped here, releasing the mutable borrows, so `webhook_routes`
+    // is usable again in the next call.
+    #[allow(clippy::drop_non_drop)]
+    drop(reg);
 
     let webhook_server = build_webhook_server(http.webhook_server_addr, webhook_routes).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,50 +46,34 @@ async fn dispatch_subcommand(cli: &Cli) -> anyhow::Result<bool> {
         return Ok(dispatched);
     }
 
-    match &cli.command {
-        Some(Command::Worker {
-            job_id,
-            orchestrator_url,
-            max_iterations,
-        }) => {
-            dispatch_worker_subcommand(*job_id, orchestrator_url, *max_iterations).await?;
-            Ok(true)
-        }
-        Some(Command::ClaudeBridge {
-            job_id,
-            orchestrator_url,
-            max_turns,
-            model,
-        }) => {
-            dispatch_claude_bridge_subcommand(*job_id, orchestrator_url, *max_turns, model).await?;
-            Ok(true)
-        }
-        Some(Command::Onboard {
-            skip_auth,
-            channels_only,
-            provider_only,
-            quick,
-        }) => {
-            run_onboard_subcommand(*skip_auth, *channels_only, *provider_only, *quick).await?;
-            Ok(true)
-        }
-        None | Some(Command::Run) => Ok(false),
-        Some(
-            Command::Tool(_)
-            | Command::Config(_)
-            | Command::Registry(_)
-            | Command::Mcp(_)
-            | Command::Memory(_)
-            | Command::Pairing(_)
-            | Command::Service(_)
-            | Command::Doctor
-            | Command::Status
-            | Command::Completion(_),
-        ) => unreachable!("CLI subcommands should have been handled earlier"),
-        #[cfg(feature = "import")]
-        Some(Command::Import(_)) => {
-            unreachable!("CLI subcommands should have been handled earlier")
-        }
+    if let Some(Command::Worker {
+        job_id,
+        orchestrator_url,
+        max_iterations,
+    }) = &cli.command
+    {
+        dispatch_worker_subcommand(*job_id, orchestrator_url, *max_iterations).await?;
+        Ok(true)
+    } else if let Some(Command::ClaudeBridge {
+        job_id,
+        orchestrator_url,
+        max_turns,
+        model,
+    }) = &cli.command
+    {
+        dispatch_claude_bridge_subcommand(*job_id, orchestrator_url, *max_turns, model).await?;
+        Ok(true)
+    } else if let Some(Command::Onboard {
+        skip_auth,
+        channels_only,
+        provider_only,
+        quick,
+    }) = &cli.command
+    {
+        run_onboard_subcommand(*skip_auth, *channels_only, *provider_only, *quick).await?;
+        Ok(true)
+    } else {
+        Ok(false)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,6 @@ fn acquire_pid_lock() -> anyhow::Result<Option<ironclaw::bootstrap::PidLock>> {
     }
 }
 
-#[allow(dead_code)]
 struct ChannelInfrastructure {
     webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>>,
     channel_names: Vec<String>,
@@ -144,23 +143,30 @@ struct ChannelInfrastructure {
     http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>>,
 }
 
-#[allow(dead_code)]
-async fn setup_channel_infrastructure(
-    cli: &Cli,
-    config: &Config,
-    components: &ironclaw::app::AppComponents,
-    channels: &ChannelManager,
-) -> anyhow::Result<ChannelInfrastructure> {
-    let mut channel_names: Vec<String> = Vec::new();
-    let mut loaded_wasm_channel_names: Vec<String> = Vec::new();
+struct WasmInfraResult {
+    #[allow(dead_code)]
+    channel_names: Vec<String>,
+    loaded_wasm_channel_names: Vec<String>,
     #[allow(clippy::type_complexity)]
-    let mut wasm_channel_runtime_state: Option<(
+    wasm_channel_runtime_state: Option<(
         Arc<WasmChannelRuntime>,
         Arc<PairingStore>,
         Arc<WasmChannelRouter>,
-    )> = None;
+    )>,
+}
 
-    // Create CLI channel
+struct HttpChannelResult {
+    webhook_server_addr: Option<std::net::SocketAddr>,
+    #[cfg(unix)]
+    http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>>,
+}
+
+async fn setup_repl_channel(
+    cli: &Cli,
+    config: &Config,
+    channels: &ChannelManager,
+    channel_names: &mut Vec<String>,
+) {
     let repl_channel = if let Some(ref msg) = cli.message {
         Some(ReplChannel::with_message(msg.clone()))
     } else if config.channels.cli.enabled {
@@ -170,124 +176,191 @@ async fn setup_channel_infrastructure(
     } else {
         None
     };
-
-    if let Some(repl) = repl_channel {
-        channels.add(Box::new(repl)).await;
-        if cli.message.is_some() {
-            tracing::debug!("Single message mode");
-        } else {
-            channel_names.push("repl".to_string());
-            tracing::debug!("REPL mode enabled");
-        }
+    let Some(repl) = repl_channel else { return };
+    channels.add(Box::new(repl)).await;
+    if cli.message.is_some() {
+        tracing::debug!("Single message mode");
+    } else {
+        channel_names.push("repl".to_string());
+        tracing::debug!("REPL mode enabled");
     }
+}
 
-    // Collect webhook route fragments; a single WebhookServer hosts them all.
+async fn setup_wasm_channels_infra(
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+    channels: &ChannelManager,
+    channel_names: &mut Vec<String>,
+    webhook_routes: &mut Vec<axum::Router>,
+) -> WasmInfraResult {
+    let empty = WasmInfraResult {
+        channel_names: vec![],
+        loaded_wasm_channel_names: vec![],
+        wasm_channel_runtime_state: None,
+    };
+    if !config.channels.wasm_channels_enabled || !config.channels.wasm_channels_dir.exists() {
+        return empty;
+    }
+    let Some(result) = ironclaw::channels::wasm::setup_wasm_channels(
+        config,
+        &components.secrets_store,
+        components.extension_manager.as_ref(),
+        components.db.as_ref(),
+    )
+    .await
+    else {
+        return empty;
+    };
+    let loaded_wasm_channel_names = result.channel_names;
+    let wasm_channel_runtime_state = Some((
+        result.wasm_channel_runtime,
+        result.pairing_store,
+        result.wasm_channel_router,
+    ));
+    let mut wasm_channel_names = Vec::new();
+    for (name, channel) in result.channels {
+        wasm_channel_names.push(name.clone());
+        channel_names.push(name);
+        channels.add(channel).await;
+    }
+    if let Some(routes) = result.webhook_routes {
+        webhook_routes.push(routes);
+    }
+    WasmInfraResult {
+        channel_names: wasm_channel_names,
+        loaded_wasm_channel_names,
+        wasm_channel_runtime_state,
+    }
+}
+
+async fn setup_signal_channel(
+    cli: &Cli,
+    config: &Config,
+    channels: &ChannelManager,
+    channel_names: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    if cli.cli_only {
+        return Ok(());
+    }
+    let Some(ref signal_config) = config.channels.signal else {
+        return Ok(());
+    };
+    let signal_channel = SignalChannel::new(signal_config.clone())?;
+    channel_names.push("signal".to_string());
+    channels.add(Box::new(signal_channel)).await;
+    let safe_url = SignalChannel::redact_url(&signal_config.http_url);
+    tracing::debug!(url = %safe_url, "Signal channel enabled");
+    if signal_config.allow_from.is_empty() {
+        tracing::warn!("Signal channel has empty allow_from list - ALL messages will be DENIED.");
+    }
+    Ok(())
+}
+
+async fn setup_http_channel(
+    cli: &Cli,
+    config: &Config,
+    channels: &ChannelManager,
+    channel_names: &mut Vec<String>,
+    webhook_routes: &mut Vec<axum::Router>,
+) -> HttpChannelResult {
+    let none_result = HttpChannelResult {
+        webhook_server_addr: None,
+        #[cfg(unix)]
+        http_channel_state: None,
+    };
+    if cli.cli_only {
+        return none_result;
+    }
+    let Some(ref http_config) = config.channels.http else {
+        return none_result;
+    };
+    let http_channel = HttpChannel::new(http_config.clone());
+    #[cfg(unix)]
+    let http_channel_state = Some(http_channel.shared_state());
+    webhook_routes.push(http_channel.routes());
+    let (host, port) = http_channel.addr();
+    let webhook_server_addr = Some(
+        format!("{}:{}", host, port)
+            .parse()
+            .expect("HttpConfig host:port must be a valid SocketAddr"),
+    );
+    channel_names.push("http".to_string());
+    channels.add(Box::new(http_channel)).await;
+    tracing::debug!(
+        "HTTP channel enabled on {}:{}",
+        http_config.host,
+        http_config.port
+    );
+    HttpChannelResult {
+        webhook_server_addr,
+        #[cfg(unix)]
+        http_channel_state,
+    }
+}
+
+async fn build_webhook_server(
+    addr: Option<std::net::SocketAddr>,
+    webhook_routes: Vec<axum::Router>,
+) -> anyhow::Result<Option<Arc<tokio::sync::Mutex<WebhookServer>>>> {
+    if webhook_routes.is_empty() {
+        return Ok(None);
+    }
+    let addr = addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 8080)));
+    if addr.ip().is_unspecified() {
+        tracing::warn!(
+            "Webhook server is binding to {} — it will be reachable from all network \
+             interfaces. Set HTTP_HOST=127.0.0.1 to restrict to localhost.",
+            addr.ip()
+        );
+    }
+    let mut server = WebhookServer::new(WebhookServerConfig { addr });
+    for routes in webhook_routes {
+        server.add_routes(routes);
+    }
+    server.start().await?;
+    Ok(Some(Arc::new(tokio::sync::Mutex::new(server))))
+}
+
+async fn setup_channel_infrastructure(
+    cli: &Cli,
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+    channels: &ChannelManager,
+) -> anyhow::Result<ChannelInfrastructure> {
+    let mut channel_names: Vec<String> = Vec::new();
     let mut webhook_routes: Vec<axum::Router> = Vec::new();
 
-    // Load WASM channels and register their webhook routes.
-    if config.channels.wasm_channels_enabled && config.channels.wasm_channels_dir.exists() {
-        let wasm_result = ironclaw::channels::wasm::setup_wasm_channels(
-            config,
-            &components.secrets_store,
-            components.extension_manager.as_ref(),
-            components.db.as_ref(),
-        )
-        .await;
+    setup_repl_channel(cli, config, channels, &mut channel_names).await;
 
-        if let Some(result) = wasm_result {
-            loaded_wasm_channel_names = result.channel_names;
-            wasm_channel_runtime_state = Some((
-                result.wasm_channel_runtime,
-                result.pairing_store,
-                result.wasm_channel_router,
-            ));
-            for (name, channel) in result.channels {
-                channel_names.push(name);
-                channels.add(channel).await;
-            }
-            if let Some(routes) = result.webhook_routes {
-                webhook_routes.push(routes);
-            }
-        }
-    }
+    let wasm = setup_wasm_channels_infra(
+        config,
+        components,
+        channels,
+        &mut channel_names,
+        &mut webhook_routes,
+    )
+    .await;
 
-    // Add Signal channel if configured and not CLI-only mode.
-    if !cli.cli_only
-        && let Some(ref signal_config) = config.channels.signal
-    {
-        let signal_channel = SignalChannel::new(signal_config.clone())?;
-        channel_names.push("signal".to_string());
-        channels.add(Box::new(signal_channel)).await;
-        let safe_url = SignalChannel::redact_url(&signal_config.http_url);
-        tracing::debug!(
-            url = %safe_url,
-            "Signal channel enabled"
-        );
-        if signal_config.allow_from.is_empty() {
-            tracing::warn!(
-                "Signal channel has empty allow_from list - ALL messages will be DENIED."
-            );
-        }
-    }
+    setup_signal_channel(cli, config, channels, &mut channel_names).await?;
 
-    // Add HTTP channel if configured and not CLI-only mode.
-    let mut webhook_server_addr: Option<std::net::SocketAddr> = None;
-    #[cfg(unix)]
-    let mut http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>> = None;
-    if !cli.cli_only
-        && let Some(ref http_config) = config.channels.http
-    {
-        let http_channel = HttpChannel::new(http_config.clone());
-        #[cfg(unix)]
-        {
-            http_channel_state = Some(http_channel.shared_state());
-        }
-        webhook_routes.push(http_channel.routes());
-        let (host, port) = http_channel.addr();
-        webhook_server_addr = Some(
-            format!("{}:{}", host, port)
-                .parse()
-                .expect("HttpConfig host:port must be a valid SocketAddr"),
-        );
-        channel_names.push("http".to_string());
-        channels.add(Box::new(http_channel)).await;
-        tracing::debug!(
-            "HTTP channel enabled on {}:{}",
-            http_config.host,
-            http_config.port
-        );
-    }
+    let http = setup_http_channel(
+        cli,
+        config,
+        channels,
+        &mut channel_names,
+        &mut webhook_routes,
+    )
+    .await;
 
-    // Start the unified webhook server if any routes were registered.
-    let webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>> = if !webhook_routes
-        .is_empty()
-    {
-        let addr =
-            webhook_server_addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 8080)));
-        if addr.ip().is_unspecified() {
-            tracing::warn!(
-                "Webhook server is binding to {} — it will be reachable from all network interfaces. \
-                 Set HTTP_HOST=127.0.0.1 to restrict to localhost.",
-                addr.ip()
-            );
-        }
-        let mut server = WebhookServer::new(WebhookServerConfig { addr });
-        for routes in webhook_routes {
-            server.add_routes(routes);
-        }
-        server.start().await?;
-        Some(Arc::new(tokio::sync::Mutex::new(server)))
-    } else {
-        None
-    };
+    let webhook_server = build_webhook_server(http.webhook_server_addr, webhook_routes).await?;
 
     Ok(ChannelInfrastructure {
         webhook_server,
         channel_names,
-        loaded_wasm_channel_names,
-        wasm_channel_runtime_state,
+        loaded_wasm_channel_names: wasm.loaded_wasm_channel_names,
+        wasm_channel_runtime_state: wasm.wasm_channel_runtime_state,
         #[cfg(unix)]
-        http_channel_state,
+        http_channel_state: http.http_channel_state,
     })
 }
 
@@ -502,135 +575,14 @@ async fn async_main() -> anyhow::Result<()> {
     // ── Channel setup ──────────────────────────────────────────────────
 
     let channels = ChannelManager::new();
-    let mut channel_names: Vec<String> = Vec::new();
-    let mut loaded_wasm_channel_names: Vec<String> = Vec::new();
-    #[allow(clippy::type_complexity)]
-    let mut wasm_channel_runtime_state: Option<(
-        Arc<WasmChannelRuntime>,
-        Arc<PairingStore>,
-        Arc<WasmChannelRouter>,
-    )> = None;
-
-    // Create CLI channel
-    let repl_channel = if let Some(ref msg) = cli.message {
-        Some(ReplChannel::with_message(msg.clone()))
-    } else if config.channels.cli.enabled {
-        let repl = ReplChannel::new();
-        repl.suppress_banner();
-        Some(repl)
-    } else {
-        None
-    };
-
-    if let Some(repl) = repl_channel {
-        channels.add(Box::new(repl)).await;
-        if cli.message.is_some() {
-            tracing::debug!("Single message mode");
-        } else {
-            channel_names.push("repl".to_string());
-            tracing::debug!("REPL mode enabled");
-        }
-    }
-
-    // Collect webhook route fragments; a single WebhookServer hosts them all.
-    let mut webhook_routes: Vec<axum::Router> = Vec::new();
-
-    // Load WASM channels and register their webhook routes.
-    if config.channels.wasm_channels_enabled && config.channels.wasm_channels_dir.exists() {
-        let wasm_result = ironclaw::channels::wasm::setup_wasm_channels(
-            &config,
-            &components.secrets_store,
-            components.extension_manager.as_ref(),
-            components.db.as_ref(),
-        )
-        .await;
-
-        if let Some(result) = wasm_result {
-            loaded_wasm_channel_names = result.channel_names;
-            wasm_channel_runtime_state = Some((
-                result.wasm_channel_runtime,
-                result.pairing_store,
-                result.wasm_channel_router,
-            ));
-            for (name, channel) in result.channels {
-                channel_names.push(name);
-                channels.add(channel).await;
-            }
-            if let Some(routes) = result.webhook_routes {
-                webhook_routes.push(routes);
-            }
-        }
-    }
-
-    // Add Signal channel if configured and not CLI-only mode.
-    if !cli.cli_only
-        && let Some(ref signal_config) = config.channels.signal
-    {
-        let signal_channel = SignalChannel::new(signal_config.clone())?;
-        channel_names.push("signal".to_string());
-        channels.add(Box::new(signal_channel)).await;
-        let safe_url = SignalChannel::redact_url(&signal_config.http_url);
-        tracing::debug!(
-            url = %safe_url,
-            "Signal channel enabled"
-        );
-        if signal_config.allow_from.is_empty() {
-            tracing::warn!(
-                "Signal channel has empty allow_from list - ALL messages will be DENIED."
-            );
-        }
-    }
-
-    // Add HTTP channel if configured and not CLI-only mode.
-    let mut webhook_server_addr: Option<std::net::SocketAddr> = None;
-    #[cfg(unix)]
-    let mut http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>> = None;
-    if !cli.cli_only
-        && let Some(ref http_config) = config.channels.http
-    {
-        let http_channel = HttpChannel::new(http_config.clone());
+    let ChannelInfrastructure {
+        webhook_server,
+        mut channel_names,
+        mut loaded_wasm_channel_names,
+        mut wasm_channel_runtime_state,
         #[cfg(unix)]
-        {
-            http_channel_state = Some(http_channel.shared_state());
-        }
-        webhook_routes.push(http_channel.routes());
-        let (host, port) = http_channel.addr();
-        webhook_server_addr = Some(
-            format!("{}:{}", host, port)
-                .parse()
-                .expect("HttpConfig host:port must be a valid SocketAddr"),
-        );
-        channel_names.push("http".to_string());
-        channels.add(Box::new(http_channel)).await;
-        tracing::debug!(
-            "HTTP channel enabled on {}:{}",
-            http_config.host,
-            http_config.port
-        );
-    }
-
-    // Start the unified webhook server if any routes were registered.
-    let webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>> = if !webhook_routes
-        .is_empty()
-    {
-        let addr =
-            webhook_server_addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 8080)));
-        if addr.ip().is_unspecified() {
-            tracing::warn!(
-                "Webhook server is binding to {} — it will be reachable from all network interfaces. \
-                 Set HTTP_HOST=127.0.0.1 to restrict to localhost.",
-                addr.ip()
-            );
-        }
-        let mut server = WebhookServer::new(WebhookServerConfig { addr });
-        for routes in webhook_routes {
-            server.add_routes(routes);
-        }
-        server.start().await?;
-        Some(Arc::new(tokio::sync::Mutex::new(server)))
-    } else {
-        None
-    };
+        http_channel_state,
+    } = setup_channel_infrastructure(&cli, &config, &components, &channels).await?;
 
     // Register lifecycle hooks.
     let active_tool_names = components.tools.list().await;
@@ -691,7 +643,7 @@ async fn async_main() -> anyhow::Result<()> {
     } = setup_gateway_channel(
         &config,
         &components,
-        &GatewayDeps {
+        &mut GatewayContext {
             container_job_manager: &container_job_manager,
             session_manager: &session_manager,
             log_broadcaster: &log_broadcaster,
@@ -699,9 +651,9 @@ async fn async_main() -> anyhow::Result<()> {
             prompt_queue: &prompt_queue,
             scheduler_slot: &scheduler_slot,
             job_event_tx: &job_event_tx,
+            channels: &channels,
+            channel_names: &mut channel_names,
         },
-        &channels,
-        &mut channel_names,
     )
     .await;
 
@@ -713,44 +665,17 @@ async fn async_main() -> anyhow::Result<()> {
         .cheap_llm
         .as_ref()
         .map(|c| c.model_name().to_string());
-
-    if config.channels.cli.enabled && cli.message.is_none() {
-        let boot_info = ironclaw::boot_screen::BootInfo {
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            agent_name: config.agent.name.clone(),
-            llm_backend: config.llm.backend.to_string(),
-            llm_model: boot_llm_model,
-            cheap_model: boot_cheap_model,
-            db_backend: if cli.no_db {
-                "none".to_string()
-            } else {
-                config.database.backend.to_string()
-            },
-            db_connected: !cli.no_db,
-            tool_count: boot_tool_count,
-            gateway_url,
-            embeddings_enabled: config.embeddings.enabled,
-            embeddings_provider: if config.embeddings.enabled {
-                Some(config.embeddings.provider.clone())
-            } else {
-                None
-            },
-            heartbeat_enabled: config.heartbeat.enabled,
-            heartbeat_interval_secs: config.heartbeat.interval_secs,
-            sandbox_enabled: config.sandbox.enabled,
-            docker_status,
-            claude_code_enabled: config.claude_code.enabled,
-            routines_enabled: config.routines.enabled,
-            skills_enabled: config.skills.enabled,
-            channels: channel_names,
-            tunnel_url: active_tunnel
-                .as_ref()
-                .and_then(|t| t.public_url())
-                .or_else(|| config.tunnel.public_url.clone()),
-            tunnel_provider: active_tunnel.as_ref().map(|t| t.name().to_string()),
-        };
-        ironclaw::boot_screen::print_boot_screen(&boot_info);
-    }
+    print_startup_info(
+        &config,
+        &cli,
+        boot_llm_model,
+        boot_cheap_model,
+        boot_tool_count,
+        gateway_url,
+        docker_status,
+        channel_names,
+        &active_tunnel,
+    );
 
     // ── Run the agent ──────────────────────────────────────────────────
 
@@ -861,52 +786,17 @@ async fn async_main() -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use ironclaw::channels::ChannelSecretUpdater;
-
-        // Collect all channels that support secret updates
         let mut secret_updaters: Vec<Arc<dyn ChannelSecretUpdater>> = Vec::new();
         if let Some(ref state) = http_channel_state {
             secret_updaters.push(Arc::clone(state) as Arc<dyn ChannelSecretUpdater>);
         }
-
-        // Construct hot-reload manager using the factory
         let reload_manager = ironclaw::reload::create_hot_reload_manager(
             sighup_settings_store.clone(),
             webhook_server.clone(),
             components.secrets_store.clone(),
             secret_updaters,
         );
-
-        let mut shutdown_rx = shutdown_tx.subscribe();
-
-        tokio::spawn(async move {
-            use tokio::signal::unix::{SignalKind, signal};
-            let mut sighup = match signal(SignalKind::hangup()) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!("Failed to register SIGHUP handler: {}", e);
-                    return;
-                }
-            };
-
-            loop {
-                // Exit loop on shutdown signal or when SIGHUP is received
-                tokio::select! {
-                    _ = shutdown_rx.recv() => {
-                        tracing::debug!("SIGHUP handler shutting down");
-                        break;
-                    }
-                    _ = sighup.recv() => {
-                        // Handle SIGHUP signal
-                    }
-                }
-                tracing::info!("SIGHUP received — reloading HTTP webhook config");
-
-                // Perform hot-reload via manager
-                if let Err(e) = reload_manager.perform_reload().await {
-                    tracing::error!("Hot-reload failed: {}", e);
-                }
-            }
-        });
+        spawn_sighup_handler(Arc::new(reload_manager), &shutdown_tx);
     }
 
     agent.run().await?;
@@ -923,6 +813,88 @@ async fn async_main() -> anyhow::Result<()> {
     .await;
 
     Ok(())
+}
+
+#[cfg(unix)]
+fn spawn_sighup_handler(
+    reload_manager: Arc<ironclaw::reload::HotReloadManager>,
+    shutdown_tx: &tokio::sync::broadcast::Sender<()>,
+) {
+    let mut shutdown_rx = shutdown_tx.subscribe();
+    tokio::spawn(async move {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sighup = match signal(SignalKind::hangup()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("Failed to register SIGHUP handler: {}", e);
+                return;
+            }
+        };
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => {
+                    tracing::debug!("SIGHUP handler shutting down");
+                    break;
+                }
+                _ = sighup.recv() => {}
+            }
+            tracing::info!("SIGHUP received — reloading HTTP webhook config");
+            if let Err(e) = reload_manager.perform_reload().await {
+                tracing::error!("Hot-reload failed: {}", e);
+            }
+        }
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_startup_info(
+    config: &Config,
+    cli: &Cli,
+    boot_llm_model: String,
+    boot_cheap_model: Option<String>,
+    boot_tool_count: usize,
+    gateway_url: Option<String>,
+    docker_status: ironclaw::sandbox::DockerStatus,
+    channel_names: Vec<String>,
+    active_tunnel: &Option<Box<dyn ironclaw::tunnel::Tunnel>>,
+) {
+    if !config.channels.cli.enabled || cli.message.is_some() {
+        return;
+    }
+    let boot_info = ironclaw::boot_screen::BootInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        agent_name: config.agent.name.clone(),
+        llm_backend: config.llm.backend.to_string(),
+        llm_model: boot_llm_model,
+        cheap_model: boot_cheap_model,
+        db_backend: if cli.no_db {
+            "none".to_string()
+        } else {
+            config.database.backend.to_string()
+        },
+        db_connected: !cli.no_db,
+        tool_count: boot_tool_count,
+        gateway_url,
+        embeddings_enabled: config.embeddings.enabled,
+        embeddings_provider: config
+            .embeddings
+            .enabled
+            .then(|| config.embeddings.provider.clone()),
+        heartbeat_enabled: config.heartbeat.enabled,
+        heartbeat_interval_secs: config.heartbeat.interval_secs,
+        sandbox_enabled: config.sandbox.enabled,
+        docker_status,
+        claude_code_enabled: config.claude_code.enabled,
+        routines_enabled: config.routines.enabled,
+        skills_enabled: config.skills.enabled,
+        channels: channel_names,
+        tunnel_url: active_tunnel
+            .as_ref()
+            .and_then(|t| t.public_url())
+            .or_else(|| config.tunnel.public_url.clone()),
+        tunnel_provider: active_tunnel.as_ref().map(|t| t.name().to_string()),
+    };
+    ironclaw::boot_screen::print_boot_screen(&boot_info);
 }
 
 async fn run_onboard_subcommand(
@@ -975,7 +947,7 @@ async fn dispatch_worker_subcommand(
 }
 
 /// Runtime-service dependencies required to configure the gateway channel.
-struct GatewayDeps<'a> {
+struct GatewayContext<'a> {
     container_job_manager: &'a Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
     session_manager: &'a Arc<ironclaw::agent::SessionManager>,
     log_broadcaster: &'a Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
@@ -992,14 +964,14 @@ struct GatewayDeps<'a> {
     job_event_tx: &'a Option<
         tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
     >,
+    channels: &'a ironclaw::channels::ChannelManager,
+    channel_names: &'a mut Vec<String>,
 }
 
 async fn setup_gateway_channel(
     config: &Config,
     components: &ironclaw::app::AppComponents,
-    deps: &GatewayDeps<'_>,
-    channels: &ironclaw::channels::ChannelManager,
-    channel_names: &mut Vec<String>,
+    ctx: &mut GatewayContext<'_>,
 ) -> GatewaySetup {
     let mut gateway_url: Option<String> = None;
     let mut sse_sender: Option<
@@ -1011,13 +983,13 @@ async fn setup_gateway_channel(
         let gw = configure_gateway_builder(
             gw_config,
             components,
-            deps.container_job_manager,
-            deps.session_manager,
-            deps.log_broadcaster,
-            deps.log_level_handle,
-            deps.prompt_queue,
-            deps.scheduler_slot,
-            deps.job_event_tx,
+            ctx.container_job_manager,
+            ctx.session_manager,
+            ctx.log_broadcaster,
+            ctx.log_level_handle,
+            ctx.prompt_queue,
+            ctx.scheduler_slot,
+            ctx.job_event_tx,
             config.sandbox.enabled,
         )
         .await;
@@ -1037,8 +1009,8 @@ async fn setup_gateway_channel(
         sse_sender = Some(gw.state().sse.sender());
         routine_engine_slot = Some(Arc::clone(&gw.state().routine_engine));
 
-        channel_names.push("gateway".to_string());
-        channels.add(Box::new(gw)).await;
+        ctx.channel_names.push("gateway".to_string());
+        ctx.channels.add(Box::new(gw)).await;
     }
 
     GatewaySetup {

--- a/src/main.rs
+++ b/src/main.rs
@@ -616,10 +616,6 @@ async fn async_main() -> anyhow::Result<()> {
     .build_components()
     .await?;
 
-    // Start deferred runtime side effects (workspace import, seeding,
-    // embedding backfill, stale job cleanup) in the background.
-    side_effects.start();
-
     let config = components.config.clone();
 
     // ── Tunnel setup ───────────────────────────────────────────────────
@@ -863,6 +859,10 @@ async fn async_main() -> anyhow::Result<()> {
         ));
         spawn_sighup_handler(reload_manager, &shutdown_tx);
     }
+
+    // Start deferred runtime side effects only after all fallible startup
+    // work has completed successfully.
+    side_effects.start()?;
 
     let run_result = agent.run().await;
 
@@ -1142,6 +1142,7 @@ struct GatewaySetup {
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};
+    use std::sync::{Mutex, OnceLock};
 
     use gag::BufferRedirect;
     use insta::assert_snapshot;
@@ -1152,6 +1153,8 @@ mod tests {
     };
 
     use super::{BootData, print_startup_info};
+
+    static STDOUT_CAPTURE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     struct TestTunnel {
         public_url: Option<String>,
@@ -1188,6 +1191,10 @@ mod tests {
     }
 
     fn capture_stdout(action: impl FnOnce()) -> String {
+        let _guard = STDOUT_CAPTURE_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("stdout capture lock should be acquired");
         let mut stdout = BufferRedirect::stdout().expect("stdout redirection should succeed");
         action();
         std::io::stdout()

--- a/src/main.rs
+++ b/src/main.rs
@@ -864,7 +864,7 @@ async fn async_main() -> anyhow::Result<()> {
         spawn_sighup_handler(reload_manager, &shutdown_tx);
     }
 
-    agent.run().await?;
+    let run_result = agent.run().await;
 
     // ── Shutdown ────────────────────────────────────────────────────────
 
@@ -876,6 +876,8 @@ async fn async_main() -> anyhow::Result<()> {
         &active_tunnel,
     )
     .await;
+
+    run_result?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,63 +42,11 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn dispatch_subcommand(cli: &Cli) -> anyhow::Result<bool> {
+    if let Some(dispatched) = dispatch_cli_subcommand(cli).await? {
+        return Ok(dispatched);
+    }
+
     match &cli.command {
-        Some(Command::Tool(c)) => {
-            init_cli_tracing();
-            run_tool_command(c.clone()).await?;
-            Ok(true)
-        }
-        Some(Command::Config(c)) => {
-            init_cli_tracing();
-            ironclaw::cli::run_config_command(c.clone()).await?;
-            Ok(true)
-        }
-        Some(Command::Registry(c)) => {
-            init_cli_tracing();
-            ironclaw::cli::run_registry_command(c.clone()).await?;
-            Ok(true)
-        }
-        Some(Command::Mcp(c)) => {
-            init_cli_tracing();
-            run_mcp_command(*c.clone()).await?;
-            Ok(true)
-        }
-        Some(Command::Memory(c)) => {
-            init_cli_tracing();
-            ironclaw::cli::run_memory_command(c).await?;
-            Ok(true)
-        }
-        Some(Command::Pairing(c)) => {
-            init_cli_tracing();
-            run_pairing_command(c.clone()).map_err(|e| anyhow::anyhow!("{}", e))?;
-            Ok(true)
-        }
-        Some(Command::Service(c)) => {
-            init_cli_tracing();
-            run_service_command(c)?;
-            Ok(true)
-        }
-        Some(Command::Doctor) => {
-            init_cli_tracing();
-            ironclaw::cli::run_doctor_command().await?;
-            Ok(true)
-        }
-        Some(Command::Status) => {
-            init_cli_tracing();
-            run_status_command().await?;
-            Ok(true)
-        }
-        Some(Command::Completion(c)) => {
-            init_cli_tracing();
-            c.run()?;
-            Ok(true)
-        }
-        #[cfg(feature = "import")]
-        Some(Command::Import(c)) => {
-            init_cli_tracing();
-            run_import_subcommand(c).await?;
-            Ok(true)
-        }
         Some(Command::Worker {
             job_id,
             orchestrator_url,
@@ -126,6 +74,90 @@ async fn dispatch_subcommand(cli: &Cli) -> anyhow::Result<bool> {
             Ok(true)
         }
         None | Some(Command::Run) => Ok(false),
+        Some(
+            Command::Tool(_)
+            | Command::Config(_)
+            | Command::Registry(_)
+            | Command::Mcp(_)
+            | Command::Memory(_)
+            | Command::Pairing(_)
+            | Command::Service(_)
+            | Command::Doctor
+            | Command::Status
+            | Command::Completion(_),
+        ) => unreachable!("CLI subcommands should have been handled earlier"),
+        #[cfg(feature = "import")]
+        Some(Command::Import(_)) => {
+            unreachable!("CLI subcommands should have been handled earlier")
+        }
+    }
+}
+
+async fn run_traced_async<F, Fut>(f: F) -> anyhow::Result<bool>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    init_cli_tracing();
+    f().await?;
+    Ok(true)
+}
+
+fn run_traced_sync<F>(f: F) -> anyhow::Result<bool>
+where
+    F: FnOnce() -> anyhow::Result<()>,
+{
+    init_cli_tracing();
+    f()?;
+    Ok(true)
+}
+
+async fn dispatch_cli_subcommand(cli: &Cli) -> anyhow::Result<Option<bool>> {
+    match &cli.command {
+        Some(Command::Tool(c)) => run_traced_async(|| async { run_tool_command(c.clone()).await })
+            .await
+            .map(Some),
+        Some(Command::Config(c)) => {
+            run_traced_async(|| async { ironclaw::cli::run_config_command(c.clone()).await })
+                .await
+                .map(Some)
+        }
+        Some(Command::Registry(c)) => {
+            run_traced_async(|| async { ironclaw::cli::run_registry_command(c.clone()).await })
+                .await
+                .map(Some)
+        }
+        Some(Command::Mcp(c)) => run_traced_async(|| async { run_mcp_command(*c.clone()).await })
+            .await
+            .map(Some),
+        Some(Command::Memory(c)) => {
+            run_traced_async(|| async { ironclaw::cli::run_memory_command(c).await })
+                .await
+                .map(Some)
+        }
+        Some(Command::Pairing(c)) => {
+            run_traced_sync(|| run_pairing_command(c.clone()).map_err(|e| anyhow::anyhow!("{}", e)))
+                .map(Some)
+        }
+        Some(Command::Service(c)) => run_traced_sync(|| run_service_command(c)).map(Some),
+        Some(Command::Doctor) => {
+            run_traced_async(|| async { ironclaw::cli::run_doctor_command().await })
+                .await
+                .map(Some)
+        }
+        Some(Command::Status) => run_traced_async(|| async { run_status_command().await })
+            .await
+            .map(Some),
+        Some(Command::Completion(c)) => run_traced_sync(|| c.run()).map(Some),
+        #[cfg(feature = "import")]
+        Some(Command::Import(c)) => run_traced_async(|| async { run_import_subcommand(c).await })
+            .await
+            .map(Some),
+        Some(Command::Worker { .. })
+        | Some(Command::ClaudeBridge { .. })
+        | Some(Command::Onboard { .. })
+        | None
+        | Some(Command::Run) => Ok(None),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,7 +550,7 @@ async fn async_main() -> anyhow::Result<()> {
 
     // Start deferred runtime side effects (workspace import, seeding,
     // embedding backfill, stale job cleanup) in the background.
-    side_effects.start().await;
+    side_effects.start();
 
     let config = components.config.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,15 +214,19 @@ async fn async_main() -> anyhow::Result<()> {
     // ── Phase 1-5: Build all core components via AppBuilder ────────────
 
     let flags = AppBuilderFlags { no_db: cli.no_db };
-    let components = AppBuilder::new(
+    let (components, side_effects) = AppBuilder::new(
         config,
         flags,
         toml_path.map(std::path::PathBuf::from),
         session.clone(),
         Arc::clone(&log_broadcaster),
     )
-    .build_all()
+    .build_components()
     .await?;
+
+    // Start deferred runtime side effects (workspace import, seeding,
+    // embedding backfill, stale job cleanup) in the background.
+    side_effects.start().await;
 
     let config = components.config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,27 +258,28 @@ async fn setup_http_channel(
     cli: &Cli,
     config: &Config,
     reg: &mut ChannelRegistrar<'_>,
-) -> HttpChannelResult {
+) -> anyhow::Result<HttpChannelResult> {
     let none_result = HttpChannelResult {
         webhook_server_addr: None,
         #[cfg(unix)]
         http_channel_state: None,
     };
     if cli.cli_only {
-        return none_result;
+        return Ok(none_result);
     }
     let Some(ref http_config) = config.channels.http else {
-        return none_result;
+        return Ok(none_result);
     };
     let http_channel = HttpChannel::new(http_config.clone());
     #[cfg(unix)]
     let http_channel_state = Some(http_channel.shared_state());
     reg.webhook_routes.push(http_channel.routes());
     let (host, port) = http_channel.addr();
+    let addr_str = format!("{}:{}", host, port);
     let webhook_server_addr = Some(
-        format!("{}:{}", host, port)
+        addr_str
             .parse()
-            .expect("HttpConfig host:port must be a valid SocketAddr"),
+            .map_err(|e| anyhow::anyhow!("Invalid HTTP host:port '{}': {}", addr_str, e))?,
     );
     reg.channel_names.push("http".to_string());
     reg.channels.add(Box::new(http_channel)).await;
@@ -287,11 +288,11 @@ async fn setup_http_channel(
         http_config.host,
         http_config.port
     );
-    HttpChannelResult {
+    Ok(HttpChannelResult {
         webhook_server_addr,
         #[cfg(unix)]
         http_channel_state,
-    }
+    })
 }
 
 async fn build_webhook_server(
@@ -338,7 +339,7 @@ async fn setup_channel_infrastructure(
 
     setup_signal_channel(cli, config, &mut reg).await?;
 
-    let http = setup_http_channel(cli, config, &mut reg).await;
+    let http = setup_http_channel(cli, config, &mut reg).await?;
 
     // `reg` is dropped here, releasing the mutable borrows, so `webhook_routes`
     // is usable again in the next call.
@@ -531,7 +532,12 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Phase 1-5: Build all core components via AppBuilder ────────────
 
-    let flags = AppBuilderFlags { no_db: cli.no_db };
+    let flags = AppBuilderFlags {
+        no_db: cli.no_db,
+        workspace_import_dir: std::env::var("WORKSPACE_IMPORT_DIR")
+            .ok()
+            .map(std::path::PathBuf::from),
+    };
     let (components, side_effects) = AppBuilder::new(
         config,
         flags,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,11 +68,13 @@ async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
             init_cli_tracing();
             Some(run_service_command(c))
         }
-        Some(Command::Doctor) => {
+        Some(Command::Doctor) =>
+        {
             #[allow(clippy::redundant_closure)]
             dispatch_cli(|| ironclaw::cli::run_doctor_command()).await
         }
-        Some(Command::Status) => {
+        Some(Command::Status) =>
+        {
             #[allow(clippy::redundant_closure)]
             dispatch_cli(|| run_status_command()).await
         }
@@ -126,6 +128,279 @@ fn acquire_pid_lock() -> anyhow::Result<Option<ironclaw::bootstrap::PidLock>> {
         }
     }
 }
+
+#[allow(dead_code)]
+struct ChannelInfrastructure {
+    webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>>,
+    channel_names: Vec<String>,
+    loaded_wasm_channel_names: Vec<String>,
+    #[allow(clippy::type_complexity)]
+    wasm_channel_runtime_state: Option<(
+        Arc<WasmChannelRuntime>,
+        Arc<PairingStore>,
+        Arc<WasmChannelRouter>,
+    )>,
+    #[cfg(unix)]
+    http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>>,
+}
+
+#[allow(dead_code)]
+async fn setup_channel_infrastructure(
+    cli: &Cli,
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+    channels: &ChannelManager,
+) -> anyhow::Result<ChannelInfrastructure> {
+    let mut channel_names: Vec<String> = Vec::new();
+    let mut loaded_wasm_channel_names: Vec<String> = Vec::new();
+    #[allow(clippy::type_complexity)]
+    let mut wasm_channel_runtime_state: Option<(
+        Arc<WasmChannelRuntime>,
+        Arc<PairingStore>,
+        Arc<WasmChannelRouter>,
+    )> = None;
+
+    // Create CLI channel
+    let repl_channel = if let Some(ref msg) = cli.message {
+        Some(ReplChannel::with_message(msg.clone()))
+    } else if config.channels.cli.enabled {
+        let repl = ReplChannel::new();
+        repl.suppress_banner();
+        Some(repl)
+    } else {
+        None
+    };
+
+    if let Some(repl) = repl_channel {
+        channels.add(Box::new(repl)).await;
+        if cli.message.is_some() {
+            tracing::debug!("Single message mode");
+        } else {
+            channel_names.push("repl".to_string());
+            tracing::debug!("REPL mode enabled");
+        }
+    }
+
+    // Collect webhook route fragments; a single WebhookServer hosts them all.
+    let mut webhook_routes: Vec<axum::Router> = Vec::new();
+
+    // Load WASM channels and register their webhook routes.
+    if config.channels.wasm_channels_enabled && config.channels.wasm_channels_dir.exists() {
+        let wasm_result = ironclaw::channels::wasm::setup_wasm_channels(
+            config,
+            &components.secrets_store,
+            components.extension_manager.as_ref(),
+            components.db.as_ref(),
+        )
+        .await;
+
+        if let Some(result) = wasm_result {
+            loaded_wasm_channel_names = result.channel_names;
+            wasm_channel_runtime_state = Some((
+                result.wasm_channel_runtime,
+                result.pairing_store,
+                result.wasm_channel_router,
+            ));
+            for (name, channel) in result.channels {
+                channel_names.push(name);
+                channels.add(channel).await;
+            }
+            if let Some(routes) = result.webhook_routes {
+                webhook_routes.push(routes);
+            }
+        }
+    }
+
+    // Add Signal channel if configured and not CLI-only mode.
+    if !cli.cli_only
+        && let Some(ref signal_config) = config.channels.signal
+    {
+        let signal_channel = SignalChannel::new(signal_config.clone())?;
+        channel_names.push("signal".to_string());
+        channels.add(Box::new(signal_channel)).await;
+        let safe_url = SignalChannel::redact_url(&signal_config.http_url);
+        tracing::debug!(
+            url = %safe_url,
+            "Signal channel enabled"
+        );
+        if signal_config.allow_from.is_empty() {
+            tracing::warn!(
+                "Signal channel has empty allow_from list - ALL messages will be DENIED."
+            );
+        }
+    }
+
+    // Add HTTP channel if configured and not CLI-only mode.
+    let mut webhook_server_addr: Option<std::net::SocketAddr> = None;
+    #[cfg(unix)]
+    let mut http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>> = None;
+    if !cli.cli_only
+        && let Some(ref http_config) = config.channels.http
+    {
+        let http_channel = HttpChannel::new(http_config.clone());
+        #[cfg(unix)]
+        {
+            http_channel_state = Some(http_channel.shared_state());
+        }
+        webhook_routes.push(http_channel.routes());
+        let (host, port) = http_channel.addr();
+        webhook_server_addr = Some(
+            format!("{}:{}", host, port)
+                .parse()
+                .expect("HttpConfig host:port must be a valid SocketAddr"),
+        );
+        channel_names.push("http".to_string());
+        channels.add(Box::new(http_channel)).await;
+        tracing::debug!(
+            "HTTP channel enabled on {}:{}",
+            http_config.host,
+            http_config.port
+        );
+    }
+
+    // Start the unified webhook server if any routes were registered.
+    let webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>> = if !webhook_routes
+        .is_empty()
+    {
+        let addr =
+            webhook_server_addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 8080)));
+        if addr.ip().is_unspecified() {
+            tracing::warn!(
+                "Webhook server is binding to {} — it will be reachable from all network interfaces. \
+                 Set HTTP_HOST=127.0.0.1 to restrict to localhost.",
+                addr.ip()
+            );
+        }
+        let mut server = WebhookServer::new(WebhookServerConfig { addr });
+        for routes in webhook_routes {
+            server.add_routes(routes);
+        }
+        server.start().await?;
+        Some(Arc::new(tokio::sync::Mutex::new(server)))
+    } else {
+        None
+    };
+
+    Ok(ChannelInfrastructure {
+        webhook_server,
+        channel_names,
+        loaded_wasm_channel_names,
+        wasm_channel_runtime_state,
+        #[cfg(unix)]
+        http_channel_state,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn wire_extension_manager(
+    extension_manager: &Option<Arc<ironclaw::extensions::ExtensionManager>>,
+    wasm_channel_runtime_state: &mut Option<(
+        Arc<WasmChannelRuntime>,
+        Arc<PairingStore>,
+        Arc<WasmChannelRouter>,
+    )>,
+    loaded_wasm_channel_names: &mut [String],
+    channels: &Arc<ChannelManager>,
+    sse_sender: &Option<tokio::sync::broadcast::Sender<ironclaw::channels::web::types::SseEvent>>,
+    wasm_channel_owner_ids: &std::collections::HashMap<String, i64>,
+) {
+    // Wire up channel runtime for hot-activation of WASM channels.
+    if let Some(ext_mgr) = extension_manager
+        && let Some((rt, ps, router)) = wasm_channel_runtime_state.take()
+    {
+        let active_at_startup: std::collections::HashSet<String> =
+            loaded_wasm_channel_names.iter().cloned().collect();
+        ext_mgr
+            .set_active_channels(loaded_wasm_channel_names.to_owned())
+            .await;
+        ext_mgr
+            .set_channel_runtime(
+                Arc::clone(channels),
+                rt,
+                ps,
+                router,
+                wasm_channel_owner_ids.clone(),
+            )
+            .await;
+        tracing::debug!("Channel runtime wired into extension manager for hot-activation");
+
+        // Auto-activate WASM channels that were active in a previous session.
+        // Relay channels are handled separately below via restore_relay_channels().
+        let persisted = ext_mgr.load_persisted_active_channels().await;
+        for name in &persisted {
+            if active_at_startup.contains(name) || ext_mgr.is_relay_channel(name).await {
+                continue;
+            }
+            match ext_mgr.activate(name).await {
+                Ok(result) => {
+                    tracing::debug!(
+                        channel = %name,
+                        message = %result.message,
+                        "Auto-activated persisted WASM channel"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        channel = %name,
+                        error = %e,
+                        "Failed to auto-activate persisted WASM channel"
+                    );
+                }
+            }
+        }
+    }
+
+    // Ensure the relay channel manager is always set (even without WASM runtime),
+    // then restore any persisted relay channels.
+    if let Some(ext_mgr) = extension_manager {
+        ext_mgr
+            .set_relay_channel_manager(Arc::clone(channels))
+            .await;
+        ext_mgr.restore_relay_channels().await;
+    }
+
+    // Wire SSE sender into extension manager for broadcasting status events.
+    if let Some(ext_mgr) = extension_manager
+        && let Some(sender) = sse_sender
+    {
+        ext_mgr.set_sse_sender(sender.clone()).await;
+    }
+}
+
+async fn run_shutdown_sequence(
+    shutdown_tx: &tokio::sync::broadcast::Sender<()>,
+    mcp_process_manager: &ironclaw::tools::mcp::McpProcessManager,
+    recording_handle: &Option<Arc<ironclaw::llm::recording::RecordingLlm>>,
+    webhook_server: &Option<Arc<tokio::sync::Mutex<WebhookServer>>>,
+    active_tunnel: &Option<Box<dyn ironclaw::tunnel::Tunnel>>,
+) {
+    // Signal background tasks (SIGHUP handler, etc.) to gracefully shut down
+    let _ = shutdown_tx.send(());
+
+    // Shut down all stdio MCP server child processes.
+    mcp_process_manager.shutdown_all().await;
+
+    // Flush LLM trace recording if enabled
+    if let Some(recorder) = recording_handle
+        && let Err(e) = recorder.flush().await
+    {
+        tracing::warn!("Failed to write LLM trace: {}", e);
+    }
+
+    if let Some(ws_arc) = webhook_server {
+        ws_arc.lock().await.shutdown().await;
+    }
+
+    if let Some(tunnel) = active_tunnel {
+        tracing::debug!("Stopping {} tunnel...", tunnel.name());
+        if let Err(e) = tunnel.stop().await {
+            tracing::warn!("Failed to stop tunnel cleanly: {}", e);
+        }
+    }
+
+    tracing::debug!("Agent shutdown complete");
+}
+
 async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -416,13 +691,15 @@ async fn async_main() -> anyhow::Result<()> {
     } = setup_gateway_channel(
         &config,
         &components,
-        &container_job_manager,
-        &session_manager,
-        &log_broadcaster,
-        &log_level_handle,
-        &prompt_queue,
-        &scheduler_slot,
-        &job_event_tx,
+        &GatewayDeps {
+            container_job_manager: &container_job_manager,
+            session_manager: &session_manager,
+            log_broadcaster: &log_broadcaster,
+            log_level_handle: &log_level_handle,
+            prompt_queue: &prompt_queue,
+            scheduler_slot: &scheduler_slot,
+            job_event_tx: &job_event_tx,
+        },
         &channels,
         &mut channel_names,
     )
@@ -486,64 +763,15 @@ async fn async_main() -> anyhow::Result<()> {
         .await;
 
     // Wire up channel runtime for hot-activation of WASM channels.
-    if let Some(ref ext_mgr) = components.extension_manager
-        && let Some((rt, ps, router)) = wasm_channel_runtime_state.take()
-    {
-        let active_at_startup: std::collections::HashSet<String> =
-            loaded_wasm_channel_names.iter().cloned().collect();
-        ext_mgr.set_active_channels(loaded_wasm_channel_names).await;
-        ext_mgr
-            .set_channel_runtime(
-                Arc::clone(&channels),
-                rt,
-                ps,
-                router,
-                config.channels.wasm_channel_owner_ids.clone(),
-            )
-            .await;
-        tracing::debug!("Channel runtime wired into extension manager for hot-activation");
-
-        // Auto-activate WASM channels that were active in a previous session.
-        // Relay channels are handled separately below via restore_relay_channels().
-        let persisted = ext_mgr.load_persisted_active_channels().await;
-        for name in &persisted {
-            if active_at_startup.contains(name) || ext_mgr.is_relay_channel(name).await {
-                continue;
-            }
-            match ext_mgr.activate(name).await {
-                Ok(result) => {
-                    tracing::debug!(
-                        channel = %name,
-                        message = %result.message,
-                        "Auto-activated persisted WASM channel"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        channel = %name,
-                        error = %e,
-                        "Failed to auto-activate persisted WASM channel"
-                    );
-                }
-            }
-        }
-    }
-
-    // Ensure the relay channel manager is always set (even without WASM runtime),
-    // then restore any persisted relay channels.
-    if let Some(ref ext_mgr) = components.extension_manager {
-        ext_mgr
-            .set_relay_channel_manager(Arc::clone(&channels))
-            .await;
-        ext_mgr.restore_relay_channels().await;
-    }
-
-    // Wire SSE sender into extension manager for broadcasting status events.
-    if let Some(ref ext_mgr) = components.extension_manager
-        && let Some(ref sender) = sse_sender
-    {
-        ext_mgr.set_sse_sender(sender.clone()).await;
-    }
+    wire_extension_manager(
+        &components.extension_manager,
+        &mut wasm_channel_runtime_state,
+        &mut loaded_wasm_channel_names[..],
+        &channels,
+        &sse_sender,
+        &config.channels.wasm_channel_owner_ids,
+    )
+    .await;
 
     // Snapshot memory for trace recording before the agent starts
     if let Some(ref recorder) = components.recording_handle
@@ -685,31 +913,14 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Shutdown ────────────────────────────────────────────────────────
 
-    // Signal background tasks (SIGHUP handler, etc.) to gracefully shut down
-    let _ = shutdown_tx.send(());
-
-    // Shut down all stdio MCP server child processes.
-    components.mcp_process_manager.shutdown_all().await;
-
-    // Flush LLM trace recording if enabled
-    if let Some(ref recorder) = components.recording_handle
-        && let Err(e) = recorder.flush().await
-    {
-        tracing::warn!("Failed to write LLM trace: {}", e);
-    }
-
-    if let Some(ref ws_arc) = webhook_server {
-        ws_arc.lock().await.shutdown().await;
-    }
-
-    if let Some(tunnel) = active_tunnel {
-        tracing::debug!("Stopping {} tunnel...", tunnel.name());
-        if let Err(e) = tunnel.stop().await {
-            tracing::warn!("Failed to stop tunnel cleanly: {}", e);
-        }
-    }
-
-    tracing::debug!("Agent shutdown complete");
+    run_shutdown_sequence(
+        &shutdown_tx,
+        &components.mcp_process_manager,
+        &components.recording_handle,
+        &webhook_server,
+        &active_tunnel,
+    )
+    .await;
 
     Ok(())
 }
@@ -763,15 +974,13 @@ async fn dispatch_worker_subcommand(
     ironclaw::worker::run_worker(job_id, orchestrator_url, max_iterations).await
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn setup_gateway_channel(
-    config: &Config,
-    components: &ironclaw::app::AppComponents,
-    container_job_manager: &Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
-    session_manager: &Arc<ironclaw::agent::SessionManager>,
-    log_broadcaster: &Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
-    log_level_handle: &Arc<ironclaw::channels::web::log_layer::LogLevelHandle>,
-    prompt_queue: &Arc<
+/// Runtime-service dependencies required to configure the gateway channel.
+struct GatewayDeps<'a> {
+    container_job_manager: &'a Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
+    session_manager: &'a Arc<ironclaw::agent::SessionManager>,
+    log_broadcaster: &'a Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
+    log_level_handle: &'a Arc<ironclaw::channels::web::log_layer::LogLevelHandle>,
+    prompt_queue: &'a Arc<
         tokio::sync::Mutex<
             std::collections::HashMap<
                 uuid::Uuid,
@@ -779,10 +988,16 @@ async fn setup_gateway_channel(
             >,
         >,
     >,
-    scheduler_slot: &ironclaw::tools::builtin::SchedulerSlot,
-    job_event_tx: &Option<
+    scheduler_slot: &'a ironclaw::tools::builtin::SchedulerSlot,
+    job_event_tx: &'a Option<
         tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
     >,
+}
+
+async fn setup_gateway_channel(
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+    deps: &GatewayDeps<'_>,
     channels: &ironclaw::channels::ChannelManager,
     channel_names: &mut Vec<String>,
 ) -> GatewaySetup {
@@ -793,48 +1008,19 @@ async fn setup_gateway_channel(
     let mut routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot> = None;
 
     if let Some(ref gw_config) = config.channels.gateway {
-        let mut gw =
-            GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
-        if let Some(ref ws) = components.workspace {
-            gw = gw.with_workspace(Arc::clone(ws));
-        }
-        gw = gw.with_session_manager(Arc::clone(session_manager));
-        gw = gw.with_log_broadcaster(Arc::clone(log_broadcaster));
-        gw = gw.with_log_level_handle(Arc::clone(log_level_handle));
-        gw = gw.with_tool_registry(Arc::clone(&components.tools));
-        if let Some(ref ext_mgr) = components.extension_manager {
-            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
-        }
-        if !components.catalog_entries.is_empty() {
-            gw = gw.with_registry_entries(components.catalog_entries.clone());
-        }
-        if let Some(ref d) = components.db {
-            gw = gw.with_store(Arc::clone(d));
-        }
-        if let Some(jm) = container_job_manager {
-            gw = gw.with_job_manager(Arc::clone(jm));
-        }
-        gw = gw.with_scheduler(scheduler_slot.clone());
-        if let Some(ref sr) = components.skill_registry {
-            gw = gw.with_skill_registry(Arc::clone(sr));
-        }
-        if let Some(ref sc) = components.skill_catalog {
-            gw = gw.with_skill_catalog(Arc::clone(sc));
-        }
-        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
-        if config.sandbox.enabled {
-            gw = gw.with_prompt_queue(Arc::clone(prompt_queue));
-
-            if let Some(tx) = job_event_tx {
-                let mut rx = tx.subscribe();
-                let gw_state = Arc::clone(gw.state());
-                tokio::spawn(async move {
-                    while let Ok((_job_id, event)) = rx.recv().await {
-                        gw_state.sse.broadcast(event);
-                    }
-                });
-            }
-        }
+        let gw = configure_gateway_builder(
+            gw_config,
+            components,
+            deps.container_job_manager,
+            deps.session_manager,
+            deps.log_broadcaster,
+            deps.log_level_handle,
+            deps.prompt_queue,
+            deps.scheduler_slot,
+            deps.job_event_tx,
+            config.sandbox.enabled,
+        )
+        .await;
 
         gateway_url = Some(format!(
             "http://{}:{}/?token={}",
@@ -866,6 +1052,73 @@ async fn setup_gateway_channel(
 // Note: spawn_sighup_handler has been removed in favor of the HotReloadManager
 // approach from the main branch, which provides better encapsulation of the
 // hot-reload logic. The SIGHUP handler is now implemented inline in async_main.
+
+#[allow(clippy::too_many_arguments)]
+async fn configure_gateway_builder(
+    gw_config: &ironclaw::config::GatewayConfig,
+    components: &ironclaw::app::AppComponents,
+    container_job_manager: &Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
+    session_manager: &Arc<ironclaw::agent::SessionManager>,
+    log_broadcaster: &Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
+    log_level_handle: &Arc<ironclaw::channels::web::log_layer::LogLevelHandle>,
+    prompt_queue: &Arc<
+        tokio::sync::Mutex<
+            std::collections::HashMap<
+                uuid::Uuid,
+                std::collections::VecDeque<ironclaw::orchestrator::api::PendingPrompt>,
+            >,
+        >,
+    >,
+    scheduler_slot: &ironclaw::tools::builtin::SchedulerSlot,
+    job_event_tx: &Option<
+        tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
+    >,
+    config_sandbox_enabled: bool,
+) -> GatewayChannel {
+    let mut gw =
+        GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
+    if let Some(ref ws) = components.workspace {
+        gw = gw.with_workspace(Arc::clone(ws));
+    }
+    gw = gw.with_session_manager(Arc::clone(session_manager));
+    gw = gw.with_log_broadcaster(Arc::clone(log_broadcaster));
+    gw = gw.with_log_level_handle(Arc::clone(log_level_handle));
+    gw = gw.with_tool_registry(Arc::clone(&components.tools));
+    if let Some(ref ext_mgr) = components.extension_manager {
+        gw = gw.with_extension_manager(Arc::clone(ext_mgr));
+    }
+    if !components.catalog_entries.is_empty() {
+        gw = gw.with_registry_entries(components.catalog_entries.clone());
+    }
+    if let Some(ref d) = components.db {
+        gw = gw.with_store(Arc::clone(d));
+    }
+    if let Some(jm) = container_job_manager {
+        gw = gw.with_job_manager(Arc::clone(jm));
+    }
+    gw = gw.with_scheduler(scheduler_slot.clone());
+    if let Some(ref sr) = components.skill_registry {
+        gw = gw.with_skill_registry(Arc::clone(sr));
+    }
+    if let Some(ref sc) = components.skill_catalog {
+        gw = gw.with_skill_catalog(Arc::clone(sc));
+    }
+    gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+    if config_sandbox_enabled {
+        gw = gw.with_prompt_queue(Arc::clone(prompt_queue));
+
+        if let Some(tx) = job_event_tx {
+            let mut rx = tx.subscribe();
+            let gw_state = Arc::clone(gw.state());
+            tokio::spawn(async move {
+                while let Ok((_job_id, event)) = rx.recv().await {
+                    gw_state.sse.broadcast(event);
+                }
+            });
+        }
+    }
+    gw
+}
 
 struct GatewaySetup {
     gateway_url: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,110 +41,66 @@ fn main() -> anyhow::Result<()> {
         .block_on(async_main())
 }
 
+async fn dispatch_cli<F, Fut>(f: F) -> Option<anyhow::Result<()>>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    init_cli_tracing();
+    Some(f().await)
+}
 async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
     match &cli.command {
-        Some(Command::Tool(tool_cmd)) => {
-            init_cli_tracing();
-            Some(run_tool_command(tool_cmd.clone()).await)
+        Some(Command::Tool(c)) => dispatch_cli(|| run_tool_command(c.clone())).await,
+        Some(Command::Config(c)) => {
+            dispatch_cli(|| ironclaw::cli::run_config_command(c.clone())).await
         }
-        Some(Command::Config(config_cmd)) => {
-            init_cli_tracing();
-            Some(ironclaw::cli::run_config_command(config_cmd.clone()).await)
+        Some(Command::Registry(c)) => {
+            dispatch_cli(|| ironclaw::cli::run_registry_command(c.clone())).await
         }
-        Some(Command::Registry(registry_cmd)) => {
+        Some(Command::Mcp(c)) => dispatch_cli(|| run_mcp_command(*c.clone())).await,
+        Some(Command::Memory(c)) => dispatch_cli(|| ironclaw::cli::run_memory_command(c)).await,
+        Some(Command::Pairing(c)) => {
             init_cli_tracing();
-            Some(ironclaw::cli::run_registry_command(registry_cmd.clone()).await)
+            Some(run_pairing_command(c.clone()).map_err(|e| anyhow::anyhow!("{}", e)))
         }
-        Some(Command::Mcp(mcp_cmd)) => {
+        Some(Command::Service(c)) => {
             init_cli_tracing();
-            Some(run_mcp_command(*mcp_cmd.clone()).await)
+            Some(run_service_command(c))
         }
-        Some(Command::Memory(mem_cmd)) => {
+        Some(Command::Doctor) => dispatch_cli(|| ironclaw::cli::run_doctor_command()).await,
+        Some(Command::Status) => dispatch_cli(|| run_status_command()).await,
+        Some(Command::Completion(c)) => {
             init_cli_tracing();
-            Some(ironclaw::cli::run_memory_command(mem_cmd).await)
-        }
-        Some(Command::Pairing(pairing_cmd)) => {
-            init_cli_tracing();
-            Some(run_pairing_command(pairing_cmd.clone()).map_err(|e| anyhow::anyhow!("{}", e)))
-        }
-        Some(Command::Service(service_cmd)) => {
-            init_cli_tracing();
-            Some(run_service_command(service_cmd))
-        }
-        Some(Command::Doctor) => {
-            init_cli_tracing();
-            Some(ironclaw::cli::run_doctor_command().await)
-        }
-        Some(Command::Status) => {
-            init_cli_tracing();
-            Some(run_status_command().await)
-        }
-        Some(Command::Completion(completion)) => {
-            init_cli_tracing();
-            Some(completion.run())
+            Some(c.run())
         }
         #[cfg(feature = "import")]
-        Some(Command::Import(import_cmd)) => {
+        Some(Command::Import(c)) => {
             init_cli_tracing();
-            Some(
-                async {
-                    let config = ironclaw::config::Config::from_env().await?;
-                    ironclaw::cli::run_import_command(import_cmd, &config).await
-                }
-                .await,
-            )
+            Some(run_import_subcommand(c).await)
         }
         Some(Command::Worker {
             job_id,
             orchestrator_url,
             max_iterations,
-        }) => {
-            init_worker_tracing();
-            Some(ironclaw::worker::run_worker(*job_id, orchestrator_url, *max_iterations).await)
-        }
+        }) => Some(dispatch_worker_subcommand(*job_id, orchestrator_url, *max_iterations).await),
         Some(Command::ClaudeBridge {
             job_id,
             orchestrator_url,
             max_turns,
             model,
-        }) => {
-            init_worker_tracing();
-            Some(
-                ironclaw::worker::run_claude_bridge(*job_id, orchestrator_url, *max_turns, model)
-                    .await,
-            )
-        }
+        }) => Some(
+            dispatch_claude_bridge_subcommand(*job_id, orchestrator_url, *max_turns, model).await,
+        ),
         Some(Command::Onboard {
             skip_auth,
             channels_only,
             provider_only,
             quick,
-        }) => Some(
-            async {
-                #[cfg(any(feature = "postgres", feature = "libsql"))]
-                {
-                    let config = SetupConfig {
-                        skip_auth: *skip_auth,
-                        channels_only: *channels_only,
-                        provider_only: *provider_only,
-                        quick: *quick,
-                    };
-                    let mut wizard = SetupWizard::with_config(config);
-                    wizard.run().await?;
-                }
-                #[cfg(not(any(feature = "postgres", feature = "libsql")))]
-                {
-                    let _ = (skip_auth, channels_only, provider_only, quick);
-                    eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
-                }
-                Ok(())
-            }
-            .await,
-        ),
-        None | Some(Command::Run) => {
-            // Continue to run agent
-            None
+        }) => {
+            Some(run_onboard_subcommand(*skip_auth, *channels_only, *provider_only, *quick).await)
         }
+        None | Some(Command::Run) => None,
     }
 }
 async fn async_main() -> anyhow::Result<()> {
@@ -797,4 +753,52 @@ async fn async_main() -> anyhow::Result<()> {
     tracing::debug!("Agent shutdown complete");
 
     Ok(())
+}
+
+async fn run_onboard_subcommand(
+    skip_auth: bool,
+    channels_only: bool,
+    provider_only: bool,
+    quick: bool,
+) -> anyhow::Result<()> {
+    #[cfg(any(feature = "postgres", feature = "libsql"))]
+    {
+        let config = SetupConfig {
+            skip_auth,
+            channels_only,
+            provider_only,
+            quick,
+        };
+        SetupWizard::with_config(config).run().await?;
+    }
+    #[cfg(not(any(feature = "postgres", feature = "libsql")))]
+    {
+        let _ = (skip_auth, channels_only, provider_only, quick);
+        eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
+    }
+    Ok(())
+}
+
+async fn run_import_subcommand(import_cmd: &ironclaw::cli::ImportCommand) -> anyhow::Result<()> {
+    let config = ironclaw::config::Config::from_env().await?;
+    ironclaw::cli::run_import_command(import_cmd, &config).await
+}
+
+async fn dispatch_claude_bridge_subcommand(
+    job_id: uuid::Uuid,
+    orchestrator_url: &str,
+    max_turns: u32,
+    model: &str,
+) -> anyhow::Result<()> {
+    init_worker_tracing();
+    ironclaw::worker::run_claude_bridge(job_id, orchestrator_url, max_turns, model).await
+}
+
+async fn dispatch_worker_subcommand(
+    job_id: uuid::Uuid,
+    orchestrator_url: &str,
+    max_iterations: u32,
+) -> anyhow::Result<()> {
+    init_worker_tracing();
+    ironclaw::worker::run_worker(job_id, orchestrator_url, max_iterations).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,80 @@ async fn run_shutdown_sequence(
 
     tracing::debug!("Agent shutdown complete");
 }
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+async fn run_first_run_onboarding_if_needed(cli: &Cli) -> anyhow::Result<()> {
+    if !cli.no_onboard
+        && let Some(reason) = ironclaw::setup::check_onboard_needed()
+    {
+        println!("Onboarding needed: {}", reason);
+        println!();
+        let mut wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+        wizard.run().await?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(feature = "postgres", feature = "libsql")))]
+async fn run_first_run_onboarding_if_needed(cli: &Cli) -> anyhow::Result<()> {
+    let _ = cli;
+    Ok(())
+}
+
+async fn load_initial_config(toml_path: Option<&std::path::Path>) -> anyhow::Result<Config> {
+    match Config::from_env_with_toml(toml_path).await {
+        Ok(c) => Ok(c),
+        Err(ironclaw::error::ConfigError::MissingRequired { key, hint }) => {
+            anyhow::bail!(
+                "Configuration error: Missing required setting '{}'. {}. \
+                 Run 'ironclaw onboard' to configure, or set the required environment variables.",
+                key,
+                hint
+            );
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+struct OrchestratorContext {
+    container_job_manager: Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
+    job_event_tx: Option<
+        tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
+    >,
+    prompt_queue: Arc<
+        tokio::sync::Mutex<
+            std::collections::HashMap<
+                uuid::Uuid,
+                std::collections::VecDeque<ironclaw::orchestrator::api::PendingPrompt>,
+            >,
+        >,
+    >,
+    docker_status: ironclaw::sandbox::DockerStatus,
+}
+
+async fn setup_orchestrator_context(
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+) -> OrchestratorContext {
+    let orch = ironclaw::orchestrator::setup_orchestrator(
+        config,
+        &components.llm,
+        &components.tools,
+        components.db.as_ref(),
+        components.secrets_store.as_ref(),
+    )
+    .await;
+    OrchestratorContext {
+        container_job_manager: orch.container_job_manager,
+        job_event_tx: orch.job_event_tx,
+        prompt_queue: orch.prompt_queue,
+        docker_status: orch.docker_status,
+    }
+}
+
 async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -500,36 +574,14 @@ async fn async_main() -> anyhow::Result<()> {
     // ── Agent startup ──────────────────────────────────────────────────
 
     // Enhanced first-run detection
-    #[cfg(any(feature = "postgres", feature = "libsql"))]
-    if !cli.no_onboard
-        && let Some(reason) = ironclaw::setup::check_onboard_needed()
-    {
-        println!("Onboarding needed: {}", reason);
-        println!();
-        let mut wizard = SetupWizard::with_config(SetupConfig {
-            quick: true,
-            ..Default::default()
-        });
-        wizard.run().await?;
-    }
+    run_first_run_onboarding_if_needed(&cli).await?;
 
     // Load initial config from env + disk + optional TOML (before DB is available).
     // Credentials may be missing at this point — that's fine. LlmConfig::resolve()
     // defers gracefully, and AppBuilder::build_all() re-resolves after loading
     // secrets from the encrypted DB.
     let toml_path = cli.config.as_deref();
-    let config = match Config::from_env_with_toml(toml_path).await {
-        Ok(c) => c,
-        Err(ironclaw::error::ConfigError::MissingRequired { key, hint }) => {
-            anyhow::bail!(
-                "Configuration error: Missing required setting '{}'. {}. \
-                 Run 'ironclaw onboard' to configure, or set the required environment variables.",
-                key,
-                hint
-            );
-        }
-        Err(e) => return Err(e.into()),
-    };
+    let config = load_initial_config(toml_path).await?;
 
     // Initialize session manager before channel setup
     let session = create_session_manager(config.llm.session.clone()).await;
@@ -576,18 +628,12 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Orchestrator / container job manager ────────────────────────────
 
-    let orch = ironclaw::orchestrator::setup_orchestrator(
-        &config,
-        &components.llm,
-        &components.tools,
-        components.db.as_ref(),
-        components.secrets_store.as_ref(),
-    )
-    .await;
-    let container_job_manager = orch.container_job_manager;
-    let job_event_tx = orch.job_event_tx;
-    let prompt_queue = orch.prompt_queue;
-    let docker_status = orch.docker_status;
+    let OrchestratorContext {
+        container_job_manager,
+        job_event_tx,
+        prompt_queue,
+        docker_status,
+    } = setup_orchestrator_context(&config, &components).await;
 
     // ── Channel setup ──────────────────────────────────────────────────
 
@@ -988,6 +1034,41 @@ struct GatewayContext<'a> {
     channel_names: &'a mut Vec<String>,
 }
 
+fn configure_gateway_builder(
+    mut gw: GatewayChannel,
+    components: &ironclaw::app::AppComponents,
+    ctx: &GatewayContext<'_>,
+) -> GatewayChannel {
+    gw = gw.with_llm_provider(Arc::clone(&components.llm));
+    if let Some(ref ws) = components.workspace {
+        gw = gw.with_workspace(Arc::clone(ws));
+    }
+    gw = gw.with_session_manager(Arc::clone(ctx.session_manager));
+    gw = gw.with_log_broadcaster(Arc::clone(ctx.log_broadcaster));
+    gw = gw.with_log_level_handle(Arc::clone(ctx.log_level_handle));
+    gw = gw.with_tool_registry(Arc::clone(&components.tools));
+    if let Some(ref ext_mgr) = components.extension_manager {
+        gw = gw.with_extension_manager(Arc::clone(ext_mgr));
+    }
+    if !components.catalog_entries.is_empty() {
+        gw = gw.with_registry_entries(components.catalog_entries.clone());
+    }
+    if let Some(ref d) = components.db {
+        gw = gw.with_store(Arc::clone(d));
+    }
+    if let Some(jm) = ctx.container_job_manager {
+        gw = gw.with_job_manager(Arc::clone(jm));
+    }
+    gw = gw.with_scheduler(ctx.scheduler_slot.clone());
+    if let Some(ref sr) = components.skill_registry {
+        gw = gw.with_skill_registry(Arc::clone(sr));
+    }
+    if let Some(ref sc) = components.skill_catalog {
+        gw = gw.with_skill_catalog(Arc::clone(sc));
+    }
+    gw.with_cost_guard(Arc::clone(&components.cost_guard))
+}
+
 async fn setup_gateway_channel(
     config: &Config,
     components: &ironclaw::app::AppComponents,
@@ -1001,34 +1082,7 @@ async fn setup_gateway_channel(
 
     if let Some(ref gw_config) = config.channels.gateway {
         let mut gw =
-            GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
-        if let Some(ref ws) = components.workspace {
-            gw = gw.with_workspace(Arc::clone(ws));
-        }
-        gw = gw.with_session_manager(Arc::clone(ctx.session_manager));
-        gw = gw.with_log_broadcaster(Arc::clone(ctx.log_broadcaster));
-        gw = gw.with_log_level_handle(Arc::clone(ctx.log_level_handle));
-        gw = gw.with_tool_registry(Arc::clone(&components.tools));
-        if let Some(ref ext_mgr) = components.extension_manager {
-            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
-        }
-        if !components.catalog_entries.is_empty() {
-            gw = gw.with_registry_entries(components.catalog_entries.clone());
-        }
-        if let Some(ref d) = components.db {
-            gw = gw.with_store(Arc::clone(d));
-        }
-        if let Some(jm) = ctx.container_job_manager {
-            gw = gw.with_job_manager(Arc::clone(jm));
-        }
-        gw = gw.with_scheduler(ctx.scheduler_slot.clone());
-        if let Some(ref sr) = components.skill_registry {
-            gw = gw.with_skill_registry(Arc::clone(sr));
-        }
-        if let Some(ref sc) = components.skill_catalog {
-            gw = gw.with_skill_catalog(Arc::clone(sc));
-        }
-        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+            configure_gateway_builder(GatewayChannel::new(gw_config.clone()), components, ctx);
         if config.sandbox.enabled {
             gw = gw.with_prompt_queue(Arc::clone(ctx.prompt_queue));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,74 +41,91 @@ fn main() -> anyhow::Result<()> {
         .block_on(async_main())
 }
 
-async fn dispatch_cli<F, Fut>(f: F) -> Option<anyhow::Result<()>>
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = anyhow::Result<()>>,
-{
-    init_cli_tracing();
-    Some(f().await)
-}
-async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
+async fn dispatch_subcommand(cli: &Cli) -> anyhow::Result<bool> {
     match &cli.command {
-        Some(Command::Tool(c)) => dispatch_cli(|| run_tool_command(c.clone())).await,
+        Some(Command::Tool(c)) => {
+            init_cli_tracing();
+            run_tool_command(c.clone()).await?;
+            Ok(true)
+        }
         Some(Command::Config(c)) => {
-            dispatch_cli(|| ironclaw::cli::run_config_command(c.clone())).await
+            init_cli_tracing();
+            ironclaw::cli::run_config_command(c.clone()).await?;
+            Ok(true)
         }
         Some(Command::Registry(c)) => {
-            dispatch_cli(|| ironclaw::cli::run_registry_command(c.clone())).await
+            init_cli_tracing();
+            ironclaw::cli::run_registry_command(c.clone()).await?;
+            Ok(true)
         }
-        Some(Command::Mcp(c)) => dispatch_cli(|| run_mcp_command(*c.clone())).await,
-        Some(Command::Memory(c)) => dispatch_cli(|| ironclaw::cli::run_memory_command(c)).await,
+        Some(Command::Mcp(c)) => {
+            init_cli_tracing();
+            run_mcp_command(*c.clone()).await?;
+            Ok(true)
+        }
+        Some(Command::Memory(c)) => {
+            init_cli_tracing();
+            ironclaw::cli::run_memory_command(c).await?;
+            Ok(true)
+        }
         Some(Command::Pairing(c)) => {
             init_cli_tracing();
-            Some(run_pairing_command(c.clone()).map_err(|e| anyhow::anyhow!("{}", e)))
+            run_pairing_command(c.clone()).map_err(|e| anyhow::anyhow!("{}", e))?;
+            Ok(true)
         }
         Some(Command::Service(c)) => {
             init_cli_tracing();
-            Some(run_service_command(c))
+            run_service_command(c)?;
+            Ok(true)
         }
-        Some(Command::Doctor) =>
-        {
-            #[allow(clippy::redundant_closure)]
-            dispatch_cli(|| ironclaw::cli::run_doctor_command()).await
+        Some(Command::Doctor) => {
+            init_cli_tracing();
+            ironclaw::cli::run_doctor_command().await?;
+            Ok(true)
         }
-        Some(Command::Status) =>
-        {
-            #[allow(clippy::redundant_closure)]
-            dispatch_cli(|| run_status_command()).await
+        Some(Command::Status) => {
+            init_cli_tracing();
+            run_status_command().await?;
+            Ok(true)
         }
         Some(Command::Completion(c)) => {
             init_cli_tracing();
-            Some(c.run())
+            c.run()?;
+            Ok(true)
         }
         #[cfg(feature = "import")]
         Some(Command::Import(c)) => {
             init_cli_tracing();
-            Some(run_import_subcommand(c).await)
+            run_import_subcommand(c).await?;
+            Ok(true)
         }
         Some(Command::Worker {
             job_id,
             orchestrator_url,
             max_iterations,
-        }) => Some(dispatch_worker_subcommand(*job_id, orchestrator_url, *max_iterations).await),
+        }) => {
+            dispatch_worker_subcommand(*job_id, orchestrator_url, *max_iterations).await?;
+            Ok(true)
+        }
         Some(Command::ClaudeBridge {
             job_id,
             orchestrator_url,
             max_turns,
             model,
-        }) => Some(
-            dispatch_claude_bridge_subcommand(*job_id, orchestrator_url, *max_turns, model).await,
-        ),
+        }) => {
+            dispatch_claude_bridge_subcommand(*job_id, orchestrator_url, *max_turns, model).await?;
+            Ok(true)
+        }
         Some(Command::Onboard {
             skip_auth,
             channels_only,
             provider_only,
             quick,
         }) => {
-            Some(run_onboard_subcommand(*skip_auth, *channels_only, *provider_only, *quick).await)
+            run_onboard_subcommand(*skip_auth, *channels_only, *provider_only, *quick).await?;
+            Ok(true)
         }
-        None | Some(Command::Run) => None,
+        None | Some(Command::Run) => Ok(false),
     }
 }
 
@@ -140,18 +157,6 @@ struct ChannelInfrastructure {
     )>,
     #[cfg(unix)]
     http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>>,
-}
-
-struct WasmInfraResult {
-    #[allow(dead_code)]
-    channel_names: Vec<String>,
-    loaded_wasm_channel_names: Vec<String>,
-    #[allow(clippy::type_complexity)]
-    wasm_channel_runtime_state: Option<(
-        Arc<WasmChannelRuntime>,
-        Arc<PairingStore>,
-        Arc<WasmChannelRouter>,
-    )>,
 }
 
 struct HttpChannelResult {
@@ -190,14 +195,16 @@ async fn setup_wasm_channels_infra(
     config: &Config,
     components: &ironclaw::app::AppComponents,
     reg: &mut ChannelRegistrar<'_>,
-) -> WasmInfraResult {
-    let empty = WasmInfraResult {
-        channel_names: vec![],
-        loaded_wasm_channel_names: vec![],
-        wasm_channel_runtime_state: None,
-    };
+) -> (
+    Vec<String>,
+    Option<(
+        Arc<WasmChannelRuntime>,
+        Arc<PairingStore>,
+        Arc<WasmChannelRouter>,
+    )>,
+) {
     if !config.channels.wasm_channels_enabled || !config.channels.wasm_channels_dir.exists() {
-        return empty;
+        return (vec![], None);
     }
     let Some(result) = ironclaw::channels::wasm::setup_wasm_channels(
         config,
@@ -207,7 +214,7 @@ async fn setup_wasm_channels_infra(
     )
     .await
     else {
-        return empty;
+        return (vec![], None);
     };
     let loaded_wasm_channel_names = result.channel_names;
     let wasm_channel_runtime_state = Some((
@@ -215,20 +222,14 @@ async fn setup_wasm_channels_infra(
         result.pairing_store,
         result.wasm_channel_router,
     ));
-    let mut wasm_channel_names = Vec::new();
     for (name, channel) in result.channels {
-        wasm_channel_names.push(name.clone());
-        reg.channel_names.push(name);
+        reg.channel_names.push(name.clone());
         reg.channels.add(channel).await;
     }
     if let Some(routes) = result.webhook_routes {
         reg.webhook_routes.push(routes);
     }
-    WasmInfraResult {
-        channel_names: wasm_channel_names,
-        loaded_wasm_channel_names,
-        wasm_channel_runtime_state,
-    }
+    (loaded_wasm_channel_names, wasm_channel_runtime_state)
 }
 
 async fn setup_signal_channel(
@@ -332,7 +333,8 @@ async fn setup_channel_infrastructure(
 
     setup_repl_channel(cli, config, &mut reg).await;
 
-    let wasm = setup_wasm_channels_infra(config, components, &mut reg).await;
+    let (loaded_wasm_channel_names, wasm_channel_runtime_state) =
+        setup_wasm_channels_infra(config, components, &mut reg).await;
 
     setup_signal_channel(cli, config, &mut reg).await?;
 
@@ -340,7 +342,10 @@ async fn setup_channel_infrastructure(
 
     // `reg` is dropped here, releasing the mutable borrows, so `webhook_routes`
     // is usable again in the next call.
-    #[allow(clippy::drop_non_drop)]
+    #[expect(
+        clippy::drop_non_drop,
+        reason = "Explicit drop to release mutable borrows"
+    )]
     drop(reg);
 
     let webhook_server = build_webhook_server(http.webhook_server_addr, webhook_routes).await?;
@@ -348,14 +353,13 @@ async fn setup_channel_infrastructure(
     Ok(ChannelInfrastructure {
         webhook_server,
         channel_names,
-        loaded_wasm_channel_names: wasm.loaded_wasm_channel_names,
-        wasm_channel_runtime_state: wasm.wasm_channel_runtime_state,
+        loaded_wasm_channel_names,
+        wasm_channel_runtime_state,
         #[cfg(unix)]
         http_channel_state: http.http_channel_state,
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn wire_extension_manager(
     extension_manager: &Option<Arc<ironclaw::extensions::ExtensionManager>>,
     wasm_channel_runtime_state: &mut Option<(
@@ -468,8 +472,9 @@ async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Handle non-agent commands first (they don't need full setup)
-    if let Some(result) = dispatch_subcommand(&cli).await {
-        return result;
+    let handled = dispatch_subcommand(&cli).await?;
+    if handled {
+        return Ok(());
     }
 
     // ── PID lock (prevent multiple instances) ────────────────────────
@@ -973,19 +978,48 @@ async fn setup_gateway_channel(
     let mut routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot> = None;
 
     if let Some(ref gw_config) = config.channels.gateway {
-        let gw = configure_gateway_builder(
-            gw_config,
-            components,
-            ctx.container_job_manager,
-            ctx.session_manager,
-            ctx.log_broadcaster,
-            ctx.log_level_handle,
-            ctx.prompt_queue,
-            ctx.scheduler_slot,
-            ctx.job_event_tx,
-            config.sandbox.enabled,
-        )
-        .await;
+        let mut gw =
+            GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
+        if let Some(ref ws) = components.workspace {
+            gw = gw.with_workspace(Arc::clone(ws));
+        }
+        gw = gw.with_session_manager(Arc::clone(ctx.session_manager));
+        gw = gw.with_log_broadcaster(Arc::clone(ctx.log_broadcaster));
+        gw = gw.with_log_level_handle(Arc::clone(ctx.log_level_handle));
+        gw = gw.with_tool_registry(Arc::clone(&components.tools));
+        if let Some(ref ext_mgr) = components.extension_manager {
+            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
+        }
+        if !components.catalog_entries.is_empty() {
+            gw = gw.with_registry_entries(components.catalog_entries.clone());
+        }
+        if let Some(ref d) = components.db {
+            gw = gw.with_store(Arc::clone(d));
+        }
+        if let Some(jm) = ctx.container_job_manager {
+            gw = gw.with_job_manager(Arc::clone(jm));
+        }
+        gw = gw.with_scheduler(ctx.scheduler_slot.clone());
+        if let Some(ref sr) = components.skill_registry {
+            gw = gw.with_skill_registry(Arc::clone(sr));
+        }
+        if let Some(ref sc) = components.skill_catalog {
+            gw = gw.with_skill_catalog(Arc::clone(sc));
+        }
+        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+        if config.sandbox.enabled {
+            gw = gw.with_prompt_queue(Arc::clone(ctx.prompt_queue));
+
+            if let Some(tx) = ctx.job_event_tx {
+                let mut rx = tx.subscribe();
+                let gw_state = Arc::clone(gw.state());
+                tokio::spawn(async move {
+                    while let Ok((_job_id, event)) = rx.recv().await {
+                        gw_state.sse.broadcast(event);
+                    }
+                });
+            }
+        }
 
         gateway_url = Some(format!(
             "http://{}:{}/?token={}",
@@ -1011,73 +1045,6 @@ async fn setup_gateway_channel(
         sse_sender,
         routine_engine_slot,
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn configure_gateway_builder(
-    gw_config: &ironclaw::config::GatewayConfig,
-    components: &ironclaw::app::AppComponents,
-    container_job_manager: &Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
-    session_manager: &Arc<ironclaw::agent::SessionManager>,
-    log_broadcaster: &Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
-    log_level_handle: &Arc<ironclaw::channels::web::log_layer::LogLevelHandle>,
-    prompt_queue: &Arc<
-        tokio::sync::Mutex<
-            std::collections::HashMap<
-                uuid::Uuid,
-                std::collections::VecDeque<ironclaw::orchestrator::api::PendingPrompt>,
-            >,
-        >,
-    >,
-    scheduler_slot: &ironclaw::tools::builtin::SchedulerSlot,
-    job_event_tx: &Option<
-        tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
-    >,
-    config_sandbox_enabled: bool,
-) -> GatewayChannel {
-    let mut gw =
-        GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
-    if let Some(ref ws) = components.workspace {
-        gw = gw.with_workspace(Arc::clone(ws));
-    }
-    gw = gw.with_session_manager(Arc::clone(session_manager));
-    gw = gw.with_log_broadcaster(Arc::clone(log_broadcaster));
-    gw = gw.with_log_level_handle(Arc::clone(log_level_handle));
-    gw = gw.with_tool_registry(Arc::clone(&components.tools));
-    if let Some(ref ext_mgr) = components.extension_manager {
-        gw = gw.with_extension_manager(Arc::clone(ext_mgr));
-    }
-    if !components.catalog_entries.is_empty() {
-        gw = gw.with_registry_entries(components.catalog_entries.clone());
-    }
-    if let Some(ref d) = components.db {
-        gw = gw.with_store(Arc::clone(d));
-    }
-    if let Some(jm) = container_job_manager {
-        gw = gw.with_job_manager(Arc::clone(jm));
-    }
-    gw = gw.with_scheduler(scheduler_slot.clone());
-    if let Some(ref sr) = components.skill_registry {
-        gw = gw.with_skill_registry(Arc::clone(sr));
-    }
-    if let Some(ref sc) = components.skill_catalog {
-        gw = gw.with_skill_catalog(Arc::clone(sc));
-    }
-    gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
-    if config_sandbox_enabled {
-        gw = gw.with_prompt_queue(Arc::clone(prompt_queue));
-
-        if let Some(tx) = job_event_tx {
-            let mut rx = tx.subscribe();
-            let gw_state = Arc::clone(gw.state());
-            tokio::spawn(async move {
-                while let Ok((_job_id, event)) = rx.recv().await {
-                    gw_state.sse.broadcast(event);
-                }
-            });
-        }
-    }
-    gw
 }
 
 struct GatewaySetup {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1058,3 +1058,119 @@ struct GatewaySetup {
     sse_sender: Option<tokio::sync::broadcast::Sender<ironclaw::channels::web::types::SseEvent>>,
     routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use gag::BufferRedirect;
+    use insta::assert_snapshot;
+    use ironclaw::{
+        config::Config,
+        sandbox::DockerStatus,
+        tunnel::{NativeTunnel, Tunnel},
+    };
+
+    use super::{BootData, print_startup_info};
+
+    struct TestTunnel {
+        public_url: Option<String>,
+    }
+
+    impl NativeTunnel for TestTunnel {
+        fn name(&self) -> &str {
+            "ngrok"
+        }
+
+        fn start<'a>(
+            &'a self,
+            _local_host: &'a str,
+            _local_port: u16,
+        ) -> impl std::future::Future<Output = anyhow::Result<String>> + Send + 'a {
+            let url = self
+                .public_url
+                .clone()
+                .expect("test tunnel should have a public URL");
+            async move { Ok(url) }
+        }
+
+        async fn stop(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+
+        fn public_url(&self) -> Option<String> {
+            self.public_url.clone()
+        }
+    }
+
+    fn capture_stdout(action: impl FnOnce()) -> String {
+        let mut stdout = BufferRedirect::stdout().expect("stdout redirection should succeed");
+        action();
+        std::io::stdout()
+            .flush()
+            .expect("stdout flush should succeed");
+
+        let mut output = String::new();
+        stdout
+            .read_to_string(&mut output)
+            .expect("captured stdout should be readable");
+        output
+    }
+
+    #[tokio::test]
+    async fn print_startup_info_matches_snapshot() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let mut config = Config::for_testing(
+            tempdir.path().join("test.db"),
+            tempdir.path().join("skills"),
+            tempdir.path().join("installed-skills"),
+        )
+        .await
+        .expect("test config should be built");
+        config.agent.name = "startup-test-agent".to_string();
+        config.llm.backend = "openai".to_string();
+        config.channels.cli.enabled = true;
+        config.embeddings.enabled = true;
+        config.embeddings.provider = "openai".to_string();
+        config.heartbeat.enabled = true;
+        config.heartbeat.interval_secs = 1_800;
+        config.sandbox.enabled = true;
+        config.claude_code.enabled = true;
+        config.routines.enabled = true;
+        config.skills.enabled = true;
+        config.tunnel.public_url = Some("https://fallback.example.test".to_string());
+
+        let cli = ironclaw::cli::Cli {
+            command: None,
+            cli_only: false,
+            no_db: false,
+            message: None,
+            config: None,
+            no_onboard: false,
+        };
+
+        let active_tunnel: Option<Box<dyn Tunnel>> = Some(Box::new(TestTunnel {
+            public_url: Some("https://runtime.ngrok.app".to_string()),
+        }));
+        let data = BootData {
+            llm_model: "gpt-4.1".to_string(),
+            cheap_model: Some("gpt-4.1-mini".to_string()),
+            tool_count: 42,
+            gateway_url: Some("http://127.0.0.1:4040/?token=startup-token".to_string()),
+            docker_status: DockerStatus::NotRunning,
+            channel_names: vec![
+                "repl".to_string(),
+                "gateway".to_string(),
+                "signal".to_string(),
+            ],
+            active_tunnel: &active_tunnel,
+        };
+
+        let output = capture_stdout(|| print_startup_info(&config, &cli, &data));
+        assert_snapshot!("startup_info_boot_screen", output);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,56 +41,58 @@ fn main() -> anyhow::Result<()> {
         .block_on(async_main())
 }
 
-async fn async_main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-
-    // Handle non-agent commands first (they don't need full setup)
+async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
     match &cli.command {
         Some(Command::Tool(tool_cmd)) => {
             init_cli_tracing();
-            return run_tool_command(tool_cmd.clone()).await;
+            Some(run_tool_command(tool_cmd.clone()).await)
         }
         Some(Command::Config(config_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_config_command(config_cmd.clone()).await;
+            Some(ironclaw::cli::run_config_command(config_cmd.clone()).await)
         }
         Some(Command::Registry(registry_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_registry_command(registry_cmd.clone()).await;
+            Some(ironclaw::cli::run_registry_command(registry_cmd.clone()).await)
         }
         Some(Command::Mcp(mcp_cmd)) => {
             init_cli_tracing();
-            return run_mcp_command(*mcp_cmd.clone()).await;
+            Some(run_mcp_command(*mcp_cmd.clone()).await)
         }
         Some(Command::Memory(mem_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_memory_command(mem_cmd).await;
+            Some(ironclaw::cli::run_memory_command(mem_cmd).await)
         }
         Some(Command::Pairing(pairing_cmd)) => {
             init_cli_tracing();
-            return run_pairing_command(pairing_cmd.clone()).map_err(|e| anyhow::anyhow!("{}", e));
+            Some(run_pairing_command(pairing_cmd.clone()).map_err(|e| anyhow::anyhow!("{}", e)))
         }
         Some(Command::Service(service_cmd)) => {
             init_cli_tracing();
-            return run_service_command(service_cmd);
+            Some(run_service_command(service_cmd))
         }
         Some(Command::Doctor) => {
             init_cli_tracing();
-            return ironclaw::cli::run_doctor_command().await;
+            Some(ironclaw::cli::run_doctor_command().await)
         }
         Some(Command::Status) => {
             init_cli_tracing();
-            return run_status_command().await;
+            Some(run_status_command().await)
         }
         Some(Command::Completion(completion)) => {
             init_cli_tracing();
-            return completion.run();
+            Some(completion.run())
         }
         #[cfg(feature = "import")]
         Some(Command::Import(import_cmd)) => {
             init_cli_tracing();
-            let config = ironclaw::config::Config::from_env().await?;
-            return ironclaw::cli::run_import_command(import_cmd, &config).await;
+            Some(
+                async {
+                    let config = ironclaw::config::Config::from_env().await?;
+                    ironclaw::cli::run_import_command(import_cmd, &config).await
+                }
+                .await,
+            )
         }
         Some(Command::Worker {
             job_id,
@@ -98,7 +100,7 @@ async fn async_main() -> anyhow::Result<()> {
             max_iterations,
         }) => {
             init_worker_tracing();
-            return ironclaw::worker::run_worker(*job_id, orchestrator_url, *max_iterations).await;
+            Some(ironclaw::worker::run_worker(*job_id, orchestrator_url, *max_iterations).await)
         }
         Some(Command::ClaudeBridge {
             job_id,
@@ -107,41 +109,50 @@ async fn async_main() -> anyhow::Result<()> {
             model,
         }) => {
             init_worker_tracing();
-            return ironclaw::worker::run_claude_bridge(
-                *job_id,
-                orchestrator_url,
-                *max_turns,
-                model,
+            Some(
+                ironclaw::worker::run_claude_bridge(*job_id, orchestrator_url, *max_turns, model)
+                    .await,
             )
-            .await;
         }
         Some(Command::Onboard {
             skip_auth,
             channels_only,
             provider_only,
             quick,
-        }) => {
-            #[cfg(any(feature = "postgres", feature = "libsql"))]
-            {
-                let config = SetupConfig {
-                    skip_auth: *skip_auth,
-                    channels_only: *channels_only,
-                    provider_only: *provider_only,
-                    quick: *quick,
-                };
-                let mut wizard = SetupWizard::with_config(config);
-                wizard.run().await?;
+        }) => Some(
+            async {
+                #[cfg(any(feature = "postgres", feature = "libsql"))]
+                {
+                    let config = SetupConfig {
+                        skip_auth: *skip_auth,
+                        channels_only: *channels_only,
+                        provider_only: *provider_only,
+                        quick: *quick,
+                    };
+                    let mut wizard = SetupWizard::with_config(config);
+                    wizard.run().await?;
+                }
+                #[cfg(not(any(feature = "postgres", feature = "libsql")))]
+                {
+                    let _ = (skip_auth, channels_only, provider_only, quick);
+                    eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
+                }
+                Ok(())
             }
-            #[cfg(not(any(feature = "postgres", feature = "libsql")))]
-            {
-                let _ = (skip_auth, channels_only, provider_only, quick);
-                eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
-            }
-            return Ok(());
-        }
+            .await,
+        ),
         None | Some(Command::Run) => {
             // Continue to run agent
+            None
         }
+    }
+}
+async fn async_main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    // Handle non-agent commands first (they don't need full setup)
+    if let Some(result) = dispatch_subcommand(&cli).await {
+        return result;
     }
 
     // ── PID lock (prevent multiple instances) ────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,6 @@ struct ChannelInfrastructure {
     webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>>,
     channel_names: Vec<String>,
     loaded_wasm_channel_names: Vec<String>,
-    #[allow(clippy::type_complexity)]
     wasm_channel_runtime_state: Option<(
         Arc<WasmChannelRuntime>,
         Arc<PairingStore>,
@@ -473,7 +472,6 @@ async fn run_shutdown_sequence(
 
     tracing::debug!("Agent shutdown complete");
 }
-
 async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -790,13 +788,13 @@ async fn async_main() -> anyhow::Result<()> {
         if let Some(ref state) = http_channel_state {
             secret_updaters.push(Arc::clone(state) as Arc<dyn ChannelSecretUpdater>);
         }
-        let reload_manager = ironclaw::reload::create_hot_reload_manager(
+        let reload_manager = Arc::new(ironclaw::reload::create_hot_reload_manager(
             sighup_settings_store.clone(),
             webhook_server.clone(),
             components.secrets_store.clone(),
             secret_updaters,
-        );
-        spawn_sighup_handler(Arc::new(reload_manager), &shutdown_tx);
+        ));
+        spawn_sighup_handler(reload_manager, &shutdown_tx);
     }
 
     agent.run().await?;
@@ -1019,11 +1017,6 @@ async fn setup_gateway_channel(
         routine_engine_slot,
     }
 }
-
-// Note: spawn_sighup_handler has been removed in favor of the HotReloadManager
-// Note: spawn_sighup_handler has been removed in favor of the HotReloadManager
-// approach from the main branch, which provides better encapsulation of the
-// hot-reload logic. The SIGHUP handler is now implemented inline in async_main.
 
 #[allow(clippy::too_many_arguments)]
 async fn configure_gateway_builder(

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,14 @@ async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
             init_cli_tracing();
             Some(run_service_command(c))
         }
-        Some(Command::Doctor) => dispatch_cli(|| ironclaw::cli::run_doctor_command()).await,
-        Some(Command::Status) => dispatch_cli(|| run_status_command()).await,
+        Some(Command::Doctor) => {
+            #[allow(clippy::redundant_closure)]
+            dispatch_cli(|| ironclaw::cli::run_doctor_command()).await
+        }
+        Some(Command::Status) => {
+            #[allow(clippy::redundant_closure)]
+            dispatch_cli(|| run_status_command()).await
+        }
         Some(Command::Completion(c)) => {
             init_cli_tracing();
             Some(c.run())
@@ -757,6 +763,7 @@ async fn dispatch_worker_subcommand(
     ironclaw::worker::run_worker(job_id, orchestrator_url, max_iterations).await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn setup_gateway_channel(
     config: &Config,
     components: &ironclaw::app::AppComponents,

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,13 +658,15 @@ async fn async_main() -> anyhow::Result<()> {
     print_startup_info(
         &config,
         &cli,
-        boot_llm_model,
-        boot_cheap_model,
-        boot_tool_count,
-        gateway_url,
-        docker_status,
-        channel_names,
-        &active_tunnel,
+        &BootData {
+            llm_model: boot_llm_model,
+            cheap_model: boot_cheap_model,
+            tool_count: boot_tool_count,
+            gateway_url,
+            docker_status,
+            channel_names,
+            active_tunnel: &active_tunnel,
+        },
     );
 
     // ── Run the agent ──────────────────────────────────────────────────
@@ -836,18 +838,18 @@ fn spawn_sighup_handler(
     });
 }
 
-#[allow(clippy::too_many_arguments)]
-fn print_startup_info(
-    config: &Config,
-    cli: &Cli,
-    boot_llm_model: String,
-    boot_cheap_model: Option<String>,
-    boot_tool_count: usize,
+/// Runtime-computed values used to populate the startup boot screen.
+struct BootData<'a> {
+    llm_model: String,
+    cheap_model: Option<String>,
+    tool_count: usize,
     gateway_url: Option<String>,
     docker_status: ironclaw::sandbox::DockerStatus,
     channel_names: Vec<String>,
-    active_tunnel: &Option<Box<dyn ironclaw::tunnel::Tunnel>>,
-) {
+    active_tunnel: &'a Option<Box<dyn ironclaw::tunnel::Tunnel>>,
+}
+
+fn print_startup_info(config: &Config, cli: &Cli, data: &BootData<'_>) {
     if !config.channels.cli.enabled || cli.message.is_some() {
         return;
     }
@@ -855,16 +857,16 @@ fn print_startup_info(
         version: env!("CARGO_PKG_VERSION").to_string(),
         agent_name: config.agent.name.clone(),
         llm_backend: config.llm.backend.to_string(),
-        llm_model: boot_llm_model,
-        cheap_model: boot_cheap_model,
+        llm_model: data.llm_model.clone(),
+        cheap_model: data.cheap_model.clone(),
         db_backend: if cli.no_db {
             "none".to_string()
         } else {
             config.database.backend.to_string()
         },
         db_connected: !cli.no_db,
-        tool_count: boot_tool_count,
-        gateway_url,
+        tool_count: data.tool_count,
+        gateway_url: data.gateway_url.clone(),
         embeddings_enabled: config.embeddings.enabled,
         embeddings_provider: config
             .embeddings
@@ -873,16 +875,17 @@ fn print_startup_info(
         heartbeat_enabled: config.heartbeat.enabled,
         heartbeat_interval_secs: config.heartbeat.interval_secs,
         sandbox_enabled: config.sandbox.enabled,
-        docker_status,
+        docker_status: data.docker_status,
         claude_code_enabled: config.claude_code.enabled,
         routines_enabled: config.routines.enabled,
         skills_enabled: config.skills.enabled,
-        channels: channel_names,
-        tunnel_url: active_tunnel
+        channels: data.channel_names.clone(),
+        tunnel_url: data
+            .active_tunnel
             .as_ref()
             .and_then(|t| t.public_url())
             .or_else(|| config.tunnel.public_url.clone()),
-        tunnel_provider: active_tunnel.as_ref().map(|t| t.name().to_string()),
+        tunnel_provider: data.active_tunnel.as_ref().map(|t| t.name().to_string()),
     };
     ironclaw::boot_screen::print_boot_screen(&boot_info);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,23 @@ async fn dispatch_subcommand(cli: &Cli) -> Option<anyhow::Result<()>> {
         None | Some(Command::Run) => None,
     }
 }
+
+fn acquire_pid_lock() -> anyhow::Result<Option<ironclaw::bootstrap::PidLock>> {
+    match ironclaw::bootstrap::PidLock::acquire() {
+        Ok(lock) => Ok(Some(lock)),
+        Err(ironclaw::bootstrap::PidLockError::AlreadyRunning { pid }) => anyhow::bail!(
+            "Another IronClaw instance is already running (PID {}). \
+             If this is incorrect, remove the stale PID file: {}",
+            pid,
+            ironclaw::bootstrap::pid_lock_path().display()
+        ),
+        Err(e) => {
+            eprintln!("Warning: Could not acquire PID lock: {}", e);
+            eprintln!("Continuing without PID lock protection.");
+            Ok(None)
+        }
+    }
+}
 async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -112,22 +129,7 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // ── PID lock (prevent multiple instances) ────────────────────────
-    let _pid_lock = match ironclaw::bootstrap::PidLock::acquire() {
-        Ok(lock) => Some(lock),
-        Err(ironclaw::bootstrap::PidLockError::AlreadyRunning { pid }) => {
-            anyhow::bail!(
-                "Another IronClaw instance is already running (PID {}). \
-                 If this is incorrect, remove the stale PID file: {}",
-                pid,
-                ironclaw::bootstrap::pid_lock_path().display()
-            );
-        }
-        Err(e) => {
-            eprintln!("Warning: Could not acquire PID lock: {}", e);
-            eprintln!("Continuing without PID lock protection.");
-            None
-        }
-    };
+    let _pid_lock = acquire_pid_lock()?;
 
     // ── Agent startup ──────────────────────────────────────────────────
 
@@ -195,7 +197,7 @@ async fn async_main() -> anyhow::Result<()> {
     // embedding backfill, stale job cleanup) in the background.
     side_effects.start().await;
 
-    let config = components.config;
+    let config = components.config.clone();
 
     // ── Tunnel setup ───────────────────────────────────────────────────
 
@@ -401,73 +403,24 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Gateway channel ────────────────────────────────────────────────
 
-    let mut gateway_url: Option<String> = None;
-    let mut sse_sender: Option<
-        tokio::sync::broadcast::Sender<ironclaw::channels::web::types::SseEvent>,
-    > = None;
-    let mut routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot> = None;
-    if let Some(ref gw_config) = config.channels.gateway {
-        let mut gw =
-            GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
-        if let Some(ref ws) = components.workspace {
-            gw = gw.with_workspace(Arc::clone(ws));
-        }
-        gw = gw.with_session_manager(Arc::clone(&session_manager));
-        gw = gw.with_log_broadcaster(Arc::clone(&log_broadcaster));
-        gw = gw.with_log_level_handle(Arc::clone(&log_level_handle));
-        gw = gw.with_tool_registry(Arc::clone(&components.tools));
-        if let Some(ref ext_mgr) = components.extension_manager {
-            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
-        }
-        if !components.catalog_entries.is_empty() {
-            gw = gw.with_registry_entries(components.catalog_entries.clone());
-        }
-        if let Some(ref d) = components.db {
-            gw = gw.with_store(Arc::clone(d));
-        }
-        if let Some(ref jm) = container_job_manager {
-            gw = gw.with_job_manager(Arc::clone(jm));
-        }
-        gw = gw.with_scheduler(scheduler_slot.clone());
-        if let Some(ref sr) = components.skill_registry {
-            gw = gw.with_skill_registry(Arc::clone(sr));
-        }
-        if let Some(ref sc) = components.skill_catalog {
-            gw = gw.with_skill_catalog(Arc::clone(sc));
-        }
-        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
-        if config.sandbox.enabled {
-            gw = gw.with_prompt_queue(Arc::clone(&prompt_queue));
-
-            if let Some(ref tx) = job_event_tx {
-                let mut rx = tx.subscribe();
-                let gw_state = Arc::clone(gw.state());
-                tokio::spawn(async move {
-                    while let Ok((_job_id, event)) = rx.recv().await {
-                        gw_state.sse.broadcast(event);
-                    }
-                });
-            }
-        }
-
-        gateway_url = Some(format!(
-            "http://{}:{}/?token={}",
-            gw_config.host,
-            gw_config.port,
-            gw.auth_token()
-        ));
-
-        tracing::debug!("Web UI: http://{}:{}/", gw_config.host, gw_config.port);
-
-        // Capture SSE sender and routine engine slot before moving gw into channels.
-        // IMPORTANT: This must come after all `with_*` calls since `rebuild_state`
-        // creates a new SseManager, which would orphan this sender.
-        sse_sender = Some(gw.state().sse.sender());
-        routine_engine_slot = Some(Arc::clone(&gw.state().routine_engine));
-
-        channel_names.push("gateway".to_string());
-        channels.add(Box::new(gw)).await;
-    }
+    let GatewaySetup {
+        gateway_url,
+        sse_sender,
+        routine_engine_slot,
+    } = setup_gateway_channel(
+        &config,
+        &components,
+        &container_job_manager,
+        &session_manager,
+        &log_broadcaster,
+        &log_level_handle,
+        &prompt_queue,
+        &scheduler_slot,
+        &job_event_tx,
+        &channels,
+        &mut channel_names,
+    )
+    .await;
 
     // ── Boot screen ────────────────────────────────────────────────────
 
@@ -779,6 +732,7 @@ async fn run_onboard_subcommand(
     Ok(())
 }
 
+#[cfg(feature = "import")]
 async fn run_import_subcommand(import_cmd: &ironclaw::cli::ImportCommand) -> anyhow::Result<()> {
     let config = ironclaw::config::Config::from_env().await?;
     ironclaw::cli::run_import_command(import_cmd, &config).await
@@ -801,4 +755,113 @@ async fn dispatch_worker_subcommand(
 ) -> anyhow::Result<()> {
     init_worker_tracing();
     ironclaw::worker::run_worker(job_id, orchestrator_url, max_iterations).await
+}
+
+async fn setup_gateway_channel(
+    config: &Config,
+    components: &ironclaw::app::AppComponents,
+    container_job_manager: &Option<Arc<ironclaw::orchestrator::ContainerJobManager>>,
+    session_manager: &Arc<ironclaw::agent::SessionManager>,
+    log_broadcaster: &Arc<ironclaw::channels::web::log_layer::LogBroadcaster>,
+    log_level_handle: &Arc<ironclaw::channels::web::log_layer::LogLevelHandle>,
+    prompt_queue: &Arc<
+        tokio::sync::Mutex<
+            std::collections::HashMap<
+                uuid::Uuid,
+                std::collections::VecDeque<ironclaw::orchestrator::api::PendingPrompt>,
+            >,
+        >,
+    >,
+    scheduler_slot: &ironclaw::tools::builtin::SchedulerSlot,
+    job_event_tx: &Option<
+        tokio::sync::broadcast::Sender<(uuid::Uuid, ironclaw::channels::web::types::SseEvent)>,
+    >,
+    channels: &ironclaw::channels::ChannelManager,
+    channel_names: &mut Vec<String>,
+) -> GatewaySetup {
+    let mut gateway_url: Option<String> = None;
+    let mut sse_sender: Option<
+        tokio::sync::broadcast::Sender<ironclaw::channels::web::types::SseEvent>,
+    > = None;
+    let mut routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot> = None;
+
+    if let Some(ref gw_config) = config.channels.gateway {
+        let mut gw =
+            GatewayChannel::new(gw_config.clone()).with_llm_provider(Arc::clone(&components.llm));
+        if let Some(ref ws) = components.workspace {
+            gw = gw.with_workspace(Arc::clone(ws));
+        }
+        gw = gw.with_session_manager(Arc::clone(session_manager));
+        gw = gw.with_log_broadcaster(Arc::clone(log_broadcaster));
+        gw = gw.with_log_level_handle(Arc::clone(log_level_handle));
+        gw = gw.with_tool_registry(Arc::clone(&components.tools));
+        if let Some(ref ext_mgr) = components.extension_manager {
+            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
+        }
+        if !components.catalog_entries.is_empty() {
+            gw = gw.with_registry_entries(components.catalog_entries.clone());
+        }
+        if let Some(ref d) = components.db {
+            gw = gw.with_store(Arc::clone(d));
+        }
+        if let Some(jm) = container_job_manager {
+            gw = gw.with_job_manager(Arc::clone(jm));
+        }
+        gw = gw.with_scheduler(scheduler_slot.clone());
+        if let Some(ref sr) = components.skill_registry {
+            gw = gw.with_skill_registry(Arc::clone(sr));
+        }
+        if let Some(ref sc) = components.skill_catalog {
+            gw = gw.with_skill_catalog(Arc::clone(sc));
+        }
+        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+        if config.sandbox.enabled {
+            gw = gw.with_prompt_queue(Arc::clone(prompt_queue));
+
+            if let Some(tx) = job_event_tx {
+                let mut rx = tx.subscribe();
+                let gw_state = Arc::clone(gw.state());
+                tokio::spawn(async move {
+                    while let Ok((_job_id, event)) = rx.recv().await {
+                        gw_state.sse.broadcast(event);
+                    }
+                });
+            }
+        }
+
+        gateway_url = Some(format!(
+            "http://{}:{}/?token={}",
+            gw_config.host,
+            gw_config.port,
+            gw.auth_token()
+        ));
+
+        tracing::debug!("Web UI: http://{}:{}/", gw_config.host, gw_config.port);
+
+        // Capture SSE sender and routine engine slot before moving gw into channels.
+        // IMPORTANT: This must come after all `with_*` calls since `rebuild_state`
+        // creates a new SseManager, which would orphan this sender.
+        sse_sender = Some(gw.state().sse.sender());
+        routine_engine_slot = Some(Arc::clone(&gw.state().routine_engine));
+
+        channel_names.push("gateway".to_string());
+        channels.add(Box::new(gw)).await;
+    }
+
+    GatewaySetup {
+        gateway_url,
+        sse_sender,
+        routine_engine_slot,
+    }
+}
+
+// Note: spawn_sighup_handler has been removed in favor of the HotReloadManager
+// Note: spawn_sighup_handler has been removed in favor of the HotReloadManager
+// approach from the main branch, which provides better encapsulation of the
+// hot-reload logic. The SIGHUP handler is now implemented inline in async_main.
+
+struct GatewaySetup {
+    gateway_url: Option<String>,
+    sse_sender: Option<tokio::sync::broadcast::Sender<ironclaw::channels::web::types::SseEvent>>,
+    routine_engine_slot: Option<ironclaw::channels::web::server::RoutineEngineSlot>,
 }

--- a/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_docker_not_installed.snap
+++ b/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_docker_not_installed.snap
@@ -1,0 +1,22 @@
+---
+source: src/boot_screen.rs
+assertion_line: 282
+expression: "&output"
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mironclaw[0m v0.2.0
+
+  [90mmodel[0m     [36mclaude-3-5-sonnet-20241022[0m  [90mcheap[0m [36mgpt-4o-mini[0m  [90mvia nearai[0m
+  [90mdatabase[0m  [36mlibsql[0m [90m(connected)[0m
+  [90mtools[0m     [36m24[0m [90mregistered[0m
+  [90mfeatures[0m  [36membeddings (openai)  heartbeat (30m)  [33msandbox (docker not installed)[0m  routines  skills[0m
+  [90mchannels[0m  [36mrepl  gateway  telegram[0m
+
+  [90mgateway[0m   [33;4mhttp://127.0.0.1:3001/?token=abc123[0m
+  [90mtunnel[0m    [33;4mhttps://abc123.ngrok.io[0m [90m(ngrok)[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_docker_not_running.snap
+++ b/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_docker_not_running.snap
@@ -1,0 +1,22 @@
+---
+source: src/boot_screen.rs
+assertion_line: 290
+expression: "&output"
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mironclaw[0m v0.2.0
+
+  [90mmodel[0m     [36mclaude-3-5-sonnet-20241022[0m  [90mcheap[0m [36mgpt-4o-mini[0m  [90mvia nearai[0m
+  [90mdatabase[0m  [36mlibsql[0m [90m(connected)[0m
+  [90mtools[0m     [36m24[0m [90mregistered[0m
+  [90mfeatures[0m  [36membeddings (openai)  heartbeat (30m)  [33msandbox (docker not running)[0m  routines  skills[0m
+  [90mchannels[0m  [36mrepl  gateway  telegram[0m
+
+  [90mgateway[0m   [33;4mhttp://127.0.0.1:3001/?token=abc123[0m
+  [90mtunnel[0m    [33;4mhttps://abc123.ngrok.io[0m [90m(ngrok)[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_full_snapshot.snap
+++ b/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_full_snapshot.snap
@@ -1,0 +1,22 @@
+---
+source: src/boot_screen.rs
+assertion_line: 260
+expression: "&output"
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mironclaw[0m v0.2.0
+
+  [90mmodel[0m     [36mclaude-3-5-sonnet-20241022[0m  [90mcheap[0m [36mgpt-4o-mini[0m  [90mvia nearai[0m
+  [90mdatabase[0m  [36mlibsql[0m [90m(connected)[0m
+  [90mtools[0m     [36m24[0m [90mregistered[0m
+  [90mfeatures[0m  [36membeddings (openai)  heartbeat (30m)  sandbox  routines  skills[0m
+  [90mchannels[0m  [36mrepl  gateway  telegram[0m
+
+  [90mgateway[0m   [33;4mhttp://127.0.0.1:3001/?token=abc123[0m
+  [90mtunnel[0m    [33;4mhttps://abc123.ngrok.io[0m [90m(ngrok)[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_minimal_snapshot.snap
+++ b/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_minimal_snapshot.snap
@@ -1,0 +1,17 @@
+---
+source: src/boot_screen.rs
+assertion_line: 267
+expression: "&output"
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mironclaw[0m v0.2.0
+
+  [90mmodel[0m     [36mgpt-4o[0m  [90mvia nearai[0m
+  [90mdatabase[0m  [36mnone[0m [90m(none)[0m
+  [90mtools[0m     [36m5[0m [90mregistered[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_no_features_snapshot.snap
+++ b/src/snapshots/ironclaw__boot_screen__tests__render_boot_screen_no_features_snapshot.snap
@@ -1,0 +1,18 @@
+---
+source: src/boot_screen.rs
+assertion_line: 274
+expression: "&output"
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mtest[0m v0.1.0
+
+  [90mmodel[0m     [36mgpt-4o[0m  [90mvia openai[0m
+  [90mdatabase[0m  [36mpostgres[0m [90m(connected)[0m
+  [90mtools[0m     [36m10[0m [90mregistered[0m
+  [90mchannels[0m  [36mrepl[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/src/snapshots/ironclaw__tests__startup_info_boot_screen.snap
+++ b/src/snapshots/ironclaw__tests__startup_info_boot_screen.snap
@@ -1,0 +1,22 @@
+---
+source: src/main.rs
+assertion_line: 1174
+expression: output
+---
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  [1mstartup-test-agent[0m v0.18.0
+
+  [90mmodel[0m     [36mgpt-4.1[0m  [90mcheap[0m [36mgpt-4.1-mini[0m  [90mvia openai[0m
+  [90mdatabase[0m  [36mlibsql[0m [90m(connected)[0m
+  [90mtools[0m     [36m42[0m [90mregistered[0m
+  [90mfeatures[0m  [36membeddings (openai)  heartbeat (30m)  [33msandbox (docker not running)[0m  claude-code  routines  skills[0m
+  [90mchannels[0m  [36mrepl  gateway  signal[0m
+
+  [90mgateway[0m   [33;4mhttp://127.0.0.1:4040/?token=startup-token[0m
+  [90mtunnel[0m    [33;4mhttps://runtime.ngrok.app[0m [90m(ngrok)[0m
+
+  [90m╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶[0m
+
+  /help for commands, /quit to exit

--- a/tests/support/test_rig/builder.rs
+++ b/tests/support/test_rig/builder.rs
@@ -304,10 +304,14 @@ impl TestRigBuilder {
         );
         builder.with_database(db);
         builder.with_llm(llm);
-        builder
-            .build_all()
+        let (components, _side_effects) = builder
+            .build_components()
             .await
-            .context("AppBuilder::build_all() failed in test rig")
+            .context("AppBuilder::build_components() failed in test rig")?;
+        // Note: Intentionally discarding RuntimeSideEffects to avoid unnecessary
+        // background work (workspace import, embedding backfill, stale job cleanup)
+        // during composition tests. This keeps tests fast and isolated.
+        Ok(components)
     }
 
     fn build_agent_deps(


### PR DESCRIPTION
Separates pure construction from mechanism-heavy activation following hexagonal architecture principles:

- Introduce RuntimeSideEffects struct to encapsulate deferred background work (stale job cleanup, workspace import/seeding, embedding backfill)
- Rename build_all() to build_components() returning (AppComponents, RuntimeSideEffects)
- Add build_all() convenience wrapper for backward compatibility
- Update main.rs to call side_effects.start().await explicitly
- Update test rig to skip side effects, avoiding unnecessary I/O during tests

This reduces test costs and blast radius for bootstrap changes.

---

## Linked issue

Closes `#10`

---

## Security impact

None. This PR makes no changes to authentication, authorisation, secret handling,
or network-facing surfaces. The only behavioural change is that background tasks
(stale job cleanup, workspace seeding, embedding backfill) are now started
explicitly via `RuntimeSideEffects::start()` rather than implicitly inside
`AppBuilder::build_all()`. Task scheduling and privilege levels are identical
to before.

## Database impact

None. No schema changes, no new queries, and no migration. The database
connection is obtained before `RuntimeSideEffects` is created and is simply
passed through; ownership semantics are unchanged.

## Blast radius

Narrow. The change touches only the bootstrap path (`src/app.rs`,
`src/main.rs`). The refactor is a pure mechanical split with a backward-
compatible `build_all()` wrapper; callers outside the test rig require no
changes. The test rig explicitly discards `RuntimeSideEffects` to prevent
background I/O during tests, confirming the separation works correctly in
isolation.

## Rollback plan

The `build_all()` convenience wrapper preserves the pre-PR call signature
exactly. Rolling back consists of reverting the PR branch; no database state,
configuration, or deployed artefact needs to change.

## Summary by Sourcery

Separate application component construction from runtime side effects and refactor main startup/CLI wiring into more modular helpers.

New Features:
- Introduce a RuntimeSideEffects abstraction that encapsulates deferred background work such as stale job cleanup, workspace import/seeding, and embedding backfill.
- Expose a build_components() path on AppBuilder that returns both AppComponents and RuntimeSideEffects, alongside a backward-compatible build_all() wrapper.
- Add structured helpers for CLI subcommand dispatch, channel and gateway setup, boot-screen printing, and shutdown/SIGHUP handling.

Enhancements:
- Refactor main.rs to use modular helper functions for PID locking, channel infrastructure, gateway configuration, startup info printing, and orderly shutdown.
- Split AppBuilder initialization into smaller, focused phases (LLM resolution, metering, skills init, and LLM config validation) to improve clarity and testability.
- Tighten the chat tool execution API by introducing a ChatToolRequest struct, simplifying standalone tool execution and related tests.

Tests:
- Update the test rig to build components without starting RuntimeSideEffects, avoiding unnecessary background I/O during tests.