### PR TITLE
Advertise hosted WASM tools in remote catalogue

### DIFF
--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -315,8 +315,7 @@ That keeps the worker HTTP adapter and the orchestrator router aligned, while
 the canonical hosted-visible catalogue filter now lives with the tool registry
 and policy layer instead of in the HTTP adapter. The current source set is
 active hosted-visible MCP tools plus active hosted-visible orchestrator-owned
-WASM tools. Later roadmap work extends that same filter seam for richer
-refresh behaviour.
+WASM tools. Later roadmap work focuses on richer refresh behaviour.
 
 On the worker side, the merged tool surface is now explicit rather than
 incidental. Startup still registers the remote proxies into the worker-local

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -314,8 +314,9 @@ and payload shapes in one shared transport module under `src/worker/api/`.
 That keeps the worker HTTP adapter and the orchestrator router aligned, while
 the canonical hosted-visible catalogue filter now lives with the tool registry
 and policy layer instead of in the HTTP adapter. The current source set is
-active hosted-visible MCP tools; later roadmap work extends that same filter
-seam for orchestrator-owned WASM tools and richer refresh behaviour.
+active hosted-visible MCP tools plus active hosted-visible orchestrator-owned
+WASM tools. Later roadmap work extends that same filter seam for richer
+refresh behaviour.
 
 On the worker side, the merged tool surface is now explicit rather than
 incidental. Startup still registers the remote proxies into the worker-local

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -133,7 +133,7 @@
     plans roadmap item `1.2.1` for proactive WebAssembly (WASM) schema
     publication across active registration paths.
   - [Extend the hosted remote-tool catalogue to include orchestrator-owned WASM tools](execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md)
-    plans roadmap item `1.2.2` for hosted advertisement of orchestrator-owned
+    plans roadmap item `1.2.2` for hosted advertisement for orchestrator-owned
     WebAssembly (WASM) tools through the shared remote catalogue path.
 
 ## RFCs

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -132,6 +132,9 @@
   - [Audit and fix WASM registration paths for proactive schema publication](execplans/1-2-1-audit-and-fix-wasm-registration-paths.md)
     plans roadmap item `1.2.1` for proactive WebAssembly (WASM) schema
     publication across active registration paths.
+  - [Extend the hosted remote-tool catalogue to include orchestrator-owned WASM tools](execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md)
+    plans roadmap item `1.2.2` for hosted advertisement of orchestrator-owned
+    WebAssembly (WASM) tools through the shared remote catalogue path.
 
 ## RFCs
 

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -1,0 +1,413 @@
+# Extend the hosted remote-tool catalogue to include orchestrator-owned WASM tools
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `1.2.2` exists to make proactive WebAssembly (WASM) schema
+advertisement the normal hosted contract, not an in-process-only benefit. After
+this work, a hosted worker must receive active orchestrator-owned WASM tool
+definitions through the same remote catalogue used for Model Context Protocol
+(MCP) tools, register local proxy wrappers from those canonical definitions, and
+stop omitting orchestrator-owned WASM tools from the tool array sent to the
+large language model (LLM).
+
+Success is observable in six ways. First, the orchestrator catalogue response
+includes hosted-visible WASM tools without creating a second WASM-only route or
+wire shape. Second, the worker registers proxies for those remote WASM tools at
+startup through the existing remote-tool path. Third, each advertised WASM tool
+retains its canonical `name`, `description`, and `parameters` values, including
+schemas recovered or overridden during `1.2.1`. Fourth, direct execution of
+ineligible or approval-gated tools still fails closed. Fifth, tests cover happy
+paths, unhappy paths, and fidelity edges at registry, orchestrator, and worker
+layers. Sixth, the design and user documentation stop describing
+orchestrator-owned WASM tools as absent from the hosted catalogue, and the
+roadmap marks `1.2.2` complete when implementation lands.
+
+This plan deliberately uses the `hexagonal-architecture` guidance narrowly. The
+goal is to keep hosted-catalogue policy in the tool system and treat the
+orchestrator HTTP layer plus the worker runtime as adapters that consume that
+policy. No repository-wide pattern transplant is required.
+
+## Approval gates
+
+- Plan approved
+  Acceptance criteria: the implementation stays within roadmap item `1.2.2`,
+  reuses the canonical hosted-visible filter seam from `1.1.2`, and does not
+  redefine the worker-orchestrator transport or introduce a WASM-specific
+  catalogue path.
+  Sign-off: human reviewer approves this ExecPlan before feature
+  implementation begins.
+- Implementation complete
+  Acceptance criteria: active orchestrator-owned WASM tools are visible through
+  the existing hosted remote catalogue, the worker registers their proxies, and
+  the catalogue continues to fail closed for tools that hosted mode cannot
+  execute.
+  Sign-off: implementer marks all milestones complete before final validation.
+- Validation passed
+  Acceptance criteria: required code and documentation gates pass with retained
+  logs, and test evidence proves both schema fidelity and hosted execution-path
+  correctness.
+  Sign-off: implementer records validation evidence immediately before commit.
+- Docs synced
+  Acceptance criteria: the roadmap, RFC 0002, architecture documents,
+  user-facing guidance, and this ExecPlan all describe the same hosted WASM
+  catalogue behaviour.
+  Sign-off: implementer completes documentation updates as the final
+  pre-commit checkpoint.
+
+## Repository orientation
+
+The following files are the core orientation points for this feature.
+
+- `docs/roadmap.md` defines `1.2.2`, its dependency on `1.1.1` and `1.2.1`,
+  and the success condition that hosted workers receive proactive WASM
+  definitions through the same catalogue path as MCP tools.
+- `docs/rfcs/0002-expose-wasm-tool-definitions.md` is the design authority for
+  why proactive schemas are the normal contract and why hosted mode must reuse
+  the existing remote catalogue rather than rediscovering schemas from failure
+  hints.
+- `src/orchestrator/api/remote_tools.rs` owns the current adapter-level source
+  allowlist through `HOSTED_REMOTE_TOOL_SOURCES`. It currently projects only
+  `HostedToolCatalogSource::Mcp`, which is the narrow seam this roadmap item
+  must broaden.
+- `src/tools/registry/hosted.rs` is the canonical hosted-visible filter and
+  lookup layer introduced by `1.1.2`. That is the policy boundary that this
+  change must reuse rather than bypass.
+- `src/tools/tool/approval_policy.rs` defines the relevant source-family
+  vocabulary, including both `HostedToolCatalogSource::Mcp` and
+  `HostedToolCatalogSource::Wasm`.
+- `src/tools/wasm/wrapper.rs` already reports
+  `HostedToolCatalogSource::Wasm`, which means the wrapper metadata surface is
+  already prepared for catalogue inclusion.
+- `src/orchestrator/api/tests/remote_tools.rs` and
+  `src/tools/registry/tests.rs` hold the current hosted-visibility regression
+  tests and already contain fixtures that distinguish MCP-visible versus
+  WASM-visible tools.
+- `src/worker/container/tests/remote_tools.rs` and
+  `src/worker/container/tests/hosted_fidelity.rs` cover worker-side proxy
+  registration and definition fidelity, and are the likely locations for the
+  behavioural proof that hosted workers now see WASM tools through the same
+  path as MCP tools.
+- `docs/users-guide.md` currently states that orchestrator-owned WASM tools
+  remain outside the hosted-visible catalogue. That text must change when the
+  feature ships.
+- `docs/worker-orchestrator-contract.md` is the relevant component-architecture
+  reference for the hosted transport boundary. Update it if the internal
+  catalogue contract description changes.
+- The user request named `docs/axinite-architecture-summary.md`, but that file
+  does not exist in this checkout. Use
+  `docs/axinite-architecture-overview.md` as the architecture overview document
+  for this feature.
+
+## Constraints
+
+- Reuse the worker-orchestrator transport from `1.1.1` unchanged. Do not add a
+  second catalogue endpoint, a WASM-only proxy route, or a new response shape.
+- Keep hosted-catalogue policy inside the tool system. The orchestrator adapter
+  and worker runtime may consume that policy, but they must not become the
+  source of truth for hosted visibility.
+- Treat this as a boundary extension, not a behavioural broadening without
+  guardrails. Approval-gated, protected, container-only, or otherwise
+  ineligible tools must remain hidden or rejected.
+- Preserve the canonical `ToolDefinition` contract:
+  `name`, `description`, and `parameters`. No WASM-specific LLM-facing schema
+  type is allowed.
+- Preserve the `1.2.1` contract that active WASM tool schemas are resolved at
+  registration time. This feature must not fall back to schema-in-error-hint as
+  a normal hosted path.
+- Apply the `hexagonal-architecture` guidance narrowly. Put policy and
+  selection logic inward, keep HTTP extraction and worker bootstrap in adapter
+  code, and avoid coupling adapters directly to each other.
+- Use `rstest` for unit and integration coverage. Add `rstest-bdd`
+  behavioural coverage if it can be done with the existing in-process mocked
+  orchestrator harness and without building a disproportionate new support
+  stack.
+- Keep new and modified source files under the repository's file-size and
+  complexity limits. Prefer extracting helpers over growing already-busy test
+  files into bumpy-road shapes.
+- Update user-facing and maintainer-facing documentation in the same delivery
+  pass, including the roadmap entry once the feature is fully implemented.
+- Check `FEATURE_PARITY.md` during implementation and update it in the same
+  branch if the hosted remote-tool behaviour tracked there changes.
+
+## Tolerances (exception triggers)
+
+- Scope: if the smallest credible implementation touches more than 12 files or
+  roughly 500 net new lines before documentation, stop and verify that work
+  from `1.2.3`, refresh behaviour, or broader runtime changes have not leaked
+  into this slice.
+- Boundary pressure: if including WASM tools requires changing `ToolDefinition`,
+  `RemoteToolCatalogResponse`, or the shared route constants, stop and document
+  why the existing transport cannot carry the feature.
+- Policy leakage: if the orchestrator adapter needs to inspect WASM-specific
+  implementation details that are not already represented through
+  `Tool`, `HostedToolCatalogSource`, `HostedToolEligibility`, or
+  `ToolDomain`, stop and introduce the narrowest inward-facing abstraction
+  instead of adding adapter-local heuristics.
+- Behavioural tests: if adding one focused `rstest-bdd` scenario would require
+  more than two new support files, external services, or Docker orchestration
+  beyond the current mocked-server harness, record that clearly and keep the
+  observable behaviour assertions in `rstest` integration tests.
+- Schema quality: if any active orchestrator-owned WASM tool still publishes a
+  placeholder schema during hosted advertisement, stop and reconcile that with
+  the completed `1.2.1` contract before declaring `1.2.2` done.
+- Approval semantics: if param-dependent approval rules can make a tool appear
+  safe in the catalogue but fail in a surprising way at execution time, stop
+  and document whether the catalogue must stay coarse-grained or gain a tighter
+  policy signal.
+
+## Risks
+
+- Risk: The implementation may broaden the hosted catalogue by only changing
+  the orchestrator constant, leaving the policy rationale implicit.
+  Severity: high
+  Likelihood: medium
+  Mitigation: keep the source-family expansion tied to explicit tests and
+  documentation that say the canonical registry-owned filter now admits both
+  hosted-safe MCP and hosted-safe WASM tools.
+
+- Risk: Hosted workers may receive WASM tools whose schema is still
+  placeholder-shaped, which would technically satisfy visibility while still
+  undermining first-call correctness.
+  Severity: high
+  Likelihood: medium
+  Mitigation: include at least one real-metadata or fidelity test that proves
+  the worker sees a non-placeholder WASM schema through the hosted catalogue.
+
+- Risk: Approval-gated tools may be visible at catalogue time but fail at
+  execution time in ways the user experiences as inconsistent.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: keep catalogue eligibility tests and execute-time rejection tests
+  aligned, including at least one param-aware unhappy path.
+
+- Risk: Documentation drift is likely because the current users guide,
+  architecture overview, worker-orchestrator contract document, roadmap, and
+  RFC 0002 all describe adjacent parts of this behaviour.
+  Severity: medium
+  Likelihood: high
+  Mitigation: treat documentation sync as its own milestone rather than a
+  final afterthought.
+
+- Risk: Introducing `rstest-bdd` into a subsystem that currently has no Gherkin
+  coverage could create more scaffolding than value.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: attempt one small in-process scenario only if it stays inside the
+  tolerances. Otherwise, document why `rstest` integration tests are the
+  proportional behavioural layer for this feature.
+
+## Milestone 1: confirm the narrow policy change and reuse boundary
+
+Start by confirming the exact hosted-visibility rule that the code must express.
+
+1. Verify in `src/tools/registry/hosted.rs` that the canonical filter already
+   projects definitions and named tools based on `HostedToolCatalogSource`,
+   approval eligibility, protected names, and `ToolDomain`.
+2. Confirm that `WasmToolWrapper` already reports
+   `HostedToolCatalogSource::Wasm` and that `1.2.1` tests prove proactive
+   schema publication for active WASM tools.
+3. Record in the implementation notes that `1.2.2` is not allowed to create a
+   parallel WASM-specific hosted-visibility pass. The correct seam is the
+   existing registry-owned filter consumed by the orchestrator adapter.
+
+Expected result: the implementer can point to one narrow policy change, most
+likely broadening the allowed hosted source family from MCP-only to
+MCP-plus-WASM, without redesigning the transport.
+
+## Milestone 2: extend the canonical hosted source set without leaking policy
+
+Make the policy change at the inward boundary and keep adapters thin.
+
+1. Update the hosted remote-tool policy in `src/orchestrator/api/remote_tools.rs`
+   so it consumes both `HostedToolCatalogSource::Mcp` and
+   `HostedToolCatalogSource::Wasm`.
+2. Keep `src/tools/registry/hosted.rs` as the single place that decides whether
+   a tool is hosted-visible or executable by name. If helper extraction is
+   needed to keep source-family logic readable, place it near the registry and
+   approval-policy types rather than in the HTTP handler.
+3. Do not add WASM-specific execution routing. The existing
+   `execute_hosted_remote_tool()` path must remain the only normal remote-tool
+   execution entry point.
+4. Sanity-check catalogue versioning. Adding WASM tools will change
+   `catalog_version` when the tool set changes, and that is expected. Document
+   the behaviour rather than treating it as churn.
+
+Expected result: the orchestrator catalogue and execute path both recognize
+hosted-safe orchestrator-owned WASM tools through the same registry-owned
+policy seam as MCP tools.
+
+## Milestone 3: add unit and behavioural tests for happy, unhappy, and edge cases
+
+The validation matrix must prove more than simple inclusion.
+
+### Unit and policy tests with `rstest`
+
+1. Extend `src/tools/registry/tests.rs` so
+   `hosted_tool_definitions(&[Mcp, Wasm])` returns both families in sorted
+   order, while MCP-only and WASM-only lookups still filter correctly.
+2. Add lookup tests for `get_hosted_tool()` that cover:
+   visible WASM tool, missing tool, approval-gated tool, and ineligible tool.
+3. Extend `src/orchestrator/api/tests/remote_tools.rs` so the catalogue
+   includes a hosted-safe WASM fixture and still excludes protected or
+   approval-gated tools.
+
+### Behavioural integration tests
+
+1. Add or extend worker-side tests in
+   `src/worker/container/tests/remote_tools.rs` to prove that a hosted worker
+   fetches a mixed catalogue, registers remote proxies, and exposes both local
+   tools and remote WASM tools through the merged reasoning surface.
+2. Add or extend fidelity coverage in
+   `src/worker/container/tests/hosted_fidelity.rs` so a WASM tool definition
+   round-trips from orchestrator catalogue to worker proxy without loss of
+   `name`, `description`, or `parameters`.
+3. Add at least one unhappy-path integration test proving that a tool outside
+   the hosted-visible set, or one requiring approval at execution time, is
+   still rejected even after the source-family broadening.
+4. If proportionate, add one focused `rstest-bdd` feature and scenario set
+   describing the hosted worker flow in plain language:
+   "Given an orchestrator-owned hosted-safe WASM tool, when the worker fetches
+   the remote catalogue, then the tool appears in the worker tool array with
+   its canonical schema."
+   Add a second unhappy-path scenario only if the step library remains small.
+   If the subsystem still lacks a practical `rstest-bdd` seam after one
+   focused attempt, document why in `Surprises & Discoveries` and keep the
+   behavioural proof in `rstest` integration tests.
+
+Expected result: the feature is locked down at the policy layer, the HTTP
+adapter layer, and the worker runtime layer, with explicit assertions around
+schema fidelity and fail-closed behaviour.
+
+## Milestone 4: synchronize design, architecture, and user documents
+
+Update the documents that describe the hosted remote-tool contract.
+
+1. Update `docs/rfcs/0002-expose-wasm-tool-definitions.md` so its implementation
+   status reflects `1.2.2` completion and its migration notes align with the
+   implemented catalogue reuse.
+2. Update `docs/users-guide.md` to explain that hosted workers now advertise
+   orchestrator-owned WASM tools through the same remote catalogue path as MCP
+   tools, while preserving the visibility rules for approval-gated and other
+   ineligible tools.
+3. Update `docs/worker-orchestrator-contract.md` if its hosted tool catalogue
+   description needs to say the source set now includes orchestrator-owned WASM
+   tools.
+4. Update `docs/axinite-architecture-overview.md` where it currently describes
+   the hosted catalogue as MCP-only or future work.
+5. Mark roadmap item `1.2.2` as done in `docs/roadmap.md` only when the
+   implementation and validation evidence are complete.
+6. Update `FEATURE_PARITY.md` if the hosted remote-tool feature matrix or notes
+   now need to acknowledge this shipped behaviour.
+
+Expected result: operators, maintainers, and roadmap readers all see the same
+contract, with no stale statement that hosted mode omits orchestrator-owned
+WASM tools.
+
+## Milestone 5: validate, record evidence, and land the feature
+
+Use the repository's documented gates and retain logs.
+
+1. Run targeted tests first while developing, using `tee` to capture logs in
+   `/tmp`, for example:
+
+   ```plaintext
+   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   cargo test -p <crate> <targeted-test> | tee /tmp/test-axinite-${BRANCH_SLUG}.out
+   ```
+
+2. Before commit, run the full repository gate:
+
+   ```plaintext
+   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   make all | tee /tmp/make-all-axinite-${BRANCH_SLUG}.out
+   ```
+
+3. Run Markdown validation for changed documentation:
+
+   ```plaintext
+   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   bunx markdownlint-cli2 \
+     docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md \
+     docs/roadmap.md \
+     docs/rfcs/0002-expose-wasm-tool-definitions.md \
+     docs/users-guide.md \
+     docs/worker-orchestrator-contract.md \
+     docs/axinite-architecture-overview.md \
+     docs/contents.md \
+     | tee /tmp/markdownlint-axinite-${BRANCH_SLUG}.out
+   ```
+
+4. Run the diff hygiene check:
+
+   ```plaintext
+   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   git diff --check | tee /tmp/diff-check-axinite-${BRANCH_SLUG}.out
+   ```
+
+5. Record the passing evidence in `Progress` and `Outcomes & Retrospective`,
+   then commit with a focused message that describes both the hosted WASM
+   catalogue extension and the reason for it.
+
+Expected result: the change lands with explicit evidence that code, tests, and
+documentation all match the hosted WASM catalogue contract.
+
+## Progress
+
+- [x] 2026-04-10T17:32:32+02:00 Researched the roadmap item, RFC 0002,
+  adjacent ExecPlans, architecture documents, user guide, worker-orchestrator
+  contract, and the current registry, orchestrator, and worker seams.
+- [x] 2026-04-10T17:32:32+02:00 Drafted this ExecPlan for roadmap item
+  `1.2.2`.
+- [ ] Implementation approved by a human reviewer.
+- [ ] Hosted source-family broadening implemented through the canonical filter
+  seam.
+- [ ] Unit and behavioural regression coverage added and passing.
+- [ ] Documentation updated, including `docs/roadmap.md` and the relevant
+  architecture references.
+- [ ] Final gates passed, evidence recorded, and feature commit created.
+
+## Surprises & Discoveries
+
+- 2026-04-10T17:32:32+02:00 The user request referenced
+  `docs/axinite-architecture-summary.md`, but this checkout contains
+  `docs/axinite-architecture-overview.md` instead. This plan uses the overview
+  plus `docs/worker-orchestrator-contract.md` as the relevant architecture
+  references.
+- 2026-04-10T17:32:32+02:00 `WasmToolWrapper` already reports
+  `HostedToolCatalogSource::Wasm`; the main implementation gap is that the
+  orchestrator's hosted source allowlist is still hard-coded to MCP-only.
+- 2026-04-10T17:32:32+02:00 This subsystem currently has no visible
+  `rstest-bdd` or `.feature` coverage, so behavioural BDD coverage needs an
+  explicit proportionality check before new harness code is introduced.
+
+## Decision Log
+
+- 2026-04-10T17:32:32+02:00 Use the existing registry-owned hosted filter seam
+  as the policy boundary for this plan.
+  Rationale: this matches roadmap item `1.1.2`, RFC 0002's migration plan, and
+  the `hexagonal-architecture` guidance to keep policy inward and adapters
+  thin.
+- 2026-04-10T17:32:32+02:00 Treat `docs/worker-orchestrator-contract.md` as a
+  required architecture update candidate alongside
+  `docs/axinite-architecture-overview.md`.
+  Rationale: the feature changes the internal description of the hosted
+  catalogue boundary even if the wire format stays stable.
+- 2026-04-10T17:32:32+02:00 Require a proportionality check before adding
+  `rstest-bdd` coverage to this subsystem.
+  Rationale: the user asked for behavioural testing where applicable, but the
+  current subsystem has no existing Gherkin harness, so the plan must preserve
+  a path to strong behavioural assertions without forcing scaffolding that
+  exceeds the feature's scope.
+
+## Outcomes & Retrospective
+
+Not started. Update this section during implementation with the final shipped
+behaviour, validation evidence, any deviations from the plan, and lessons that
+should inform `1.2.3` and `1.2.4`.

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -395,7 +395,8 @@ documentation all match the hosted WASM catalogue contract.
   `HostedToolCatalogSource::Wasm`; the main implementation gap is that the
   orchestrator's hosted source allowlist is still hard-coded to MCP-only.
 - 2026-04-10T17:32:32+02:00 This subsystem currently has no visible
-  `rstest-bdd` or `.feature` coverage, so behavioural BDD coverage needs an
+  `rstest-bdd` or `.feature` coverage, so behavioural BDD
+  (behaviour-driven development) coverage needs an
   explicit proportionality check before new harness code is introduced.
 - 2026-04-10T19:36:00+02:00 `src/tools/registry/tests.rs` already contains a
   hosted-visible WASM fixture and `src/worker/container/tests/remote_tools.rs`

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -377,7 +377,7 @@ documentation all match the hosted WASM catalogue contract.
   and passing in targeted runs for registry lookups, orchestrator catalogue and
   execute flows, worker remote-tool registration, and worker fidelity.
 - [x] 2026-04-10T19:56:00+02:00 Documentation updated, including
-  `docs/roadmap.md`, RFC 0002, the users guide, and the relevant architecture
+  `docs/roadmap.md`, RFC 0002, the user's guide, and the relevant architecture
   references.
 - [x] 2026-04-10T20:21:00+02:00 Final gates passed and evidence recorded:
   targeted `cargo test` runs, `make all`, Markdown lint, and `git diff --check`

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -187,7 +187,7 @@ The following files are the core orientation points for this feature.
   Mitigation: keep catalogue eligibility tests and execute-time rejection tests
   aligned, including at least one param-aware unhappy path.
 
-- Risk: Documentation drift is likely because the current users guide,
+- Risk: Documentation drift is likely because the current user's guide,
   architecture overview, worker-orchestrator contract document, roadmap, and
   RFC 0002 all describe adjacent parts of this behaviour.
   Severity: medium

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -318,21 +318,21 @@ Use the repository's documented gates and retain logs.
    `/tmp`, for example:
 
    ```plaintext
-   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   BRANCH_SLUG=$(git branch --show-current | tr '/' '-')
    cargo test -p <crate> <targeted-test> | tee /tmp/test-axinite-${BRANCH_SLUG}.out
    ```
 
 2. Before commit, run the full repository gate:
 
    ```plaintext
-   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   BRANCH_SLUG=$(git branch --show-current | tr '/' '-')
    make all | tee /tmp/make-all-axinite-${BRANCH_SLUG}.out
    ```
 
 3. Run Markdown validation for changed documentation:
 
    ```plaintext
-   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   BRANCH_SLUG=$(git branch --show-current | tr '/' '-')
    bunx markdownlint-cli2 \
      docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md \
      docs/roadmap.md \
@@ -347,7 +347,7 @@ Use the repository's documented gates and retain logs.
 4. Run the diff hygiene check:
 
    ```plaintext
-   BRANCH_SLUG=$(git branch --show | tr '/' '-')
+   BRANCH_SLUG=$(git branch --show-current | tr '/' '-')
    git diff --check | tee /tmp/diff-check-axinite-${BRANCH_SLUG}.out
    ```
 

--- a/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
+++ b/docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -366,12 +366,23 @@ documentation all match the hosted WASM catalogue contract.
 - [x] 2026-04-10T17:32:32+02:00 Drafted this ExecPlan for roadmap item
   `1.2.2`.
 - [ ] Implementation approved by a human reviewer.
-- [ ] Hosted source-family broadening implemented through the canonical filter
-  seam.
-- [ ] Unit and behavioural regression coverage added and passing.
-- [ ] Documentation updated, including `docs/roadmap.md` and the relevant
-  architecture references.
-- [ ] Final gates passed, evidence recorded, and feature commit created.
+- [x] 2026-04-10T19:36:00+02:00 Reconfirmed that the worker-side proxy
+  registration path is already generic over remote `ToolDefinition` values, so
+  `1.2.2` remains a narrow hosted-visibility extension rather than a transport
+  redesign.
+- [x] 2026-04-10T19:56:00+02:00 Hosted source-family broadening implemented
+  through the canonical filter seam by extending
+  `src/orchestrator/api/remote_tools.rs` from MCP-only to MCP-plus-WASM.
+- [x] 2026-04-10T19:56:00+02:00 Unit and behavioural regression coverage added
+  and passing in targeted runs for registry lookups, orchestrator catalogue and
+  execute flows, worker remote-tool registration, and worker fidelity.
+- [x] 2026-04-10T19:56:00+02:00 Documentation updated, including
+  `docs/roadmap.md`, RFC 0002, the users guide, and the relevant architecture
+  references.
+- [x] 2026-04-10T20:21:00+02:00 Final gates passed and evidence recorded:
+  targeted `cargo test` runs, `make all`, Markdown lint, and `git diff --check`
+  all succeeded.
+- [ ] Feature commit created.
 
 ## Surprises & Discoveries
 
@@ -386,6 +397,21 @@ documentation all match the hosted WASM catalogue contract.
 - 2026-04-10T17:32:32+02:00 This subsystem currently has no visible
   `rstest-bdd` or `.feature` coverage, so behavioural BDD coverage needs an
   explicit proportionality check before new harness code is introduced.
+- 2026-04-10T19:36:00+02:00 `src/tools/registry/tests.rs` already contains a
+  hosted-visible WASM fixture and `src/worker/container/tests/remote_tools.rs`
+  already proves that the worker merges remote catalogue definitions into its
+  local reasoning surface. The remaining test work is to broaden those
+  assertions from MCP-only to mixed MCP-plus-WASM catalogues and preserve
+  schema fidelity.
+- 2026-04-10T19:36:00+02:00 A fresh proportionality check still points away
+  from `rstest-bdd` for this slice. The subsystem has no existing BDD harness,
+  and equivalent observable behaviour can be locked down in the existing
+  `rstest` integration tests without adding new support files or feature
+  plumbing.
+- 2026-04-10T19:56:00+02:00 The worker runtime did not need any source-aware
+  changes. Once the orchestrator catalogue admitted hosted-visible WASM tools,
+  the existing remote proxy registration path accepted them unchanged because it
+  already consumes only canonical `ToolDefinition` values.
 
 ## Decision Log
 
@@ -405,9 +431,43 @@ documentation all match the hosted WASM catalogue contract.
   current subsystem has no existing Gherkin harness, so the plan must preserve
   a path to strong behavioural assertions without forcing scaffolding that
   exceeds the feature's scope.
+- 2026-04-10T19:36:00+02:00 Keep the behavioural proof in the existing
+  `rstest` integration suites rather than introducing new `rstest-bdd`
+  scaffolding for `1.2.2`.
+  Rationale: the existing worker/orchestrator harness already exercises the
+  exact observable catalogue fetch and proxy-registration flow. Adding BDD
+  support here would create disproportionate scaffolding for no contract gain.
+- 2026-04-10T19:56:00+02:00 Express the policy change at the orchestrator
+  adapter seam by broadening `HOSTED_REMOTE_TOOL_SOURCES` rather than altering
+  `ToolRegistry::hosted_tool_definitions()` or the shared transport types.
+  Rationale: the registry already owned the hosted-visibility predicate, and
+  the shared transport already carried the canonical `ToolDefinition` shape.
 
 ## Outcomes & Retrospective
 
-Not started. Update this section during implementation with the final shipped
-behaviour, validation evidence, any deviations from the plan, and lessons that
-should inform `1.2.3` and `1.2.4`.
+- 2026-04-10T20:21:00+02:00 Shipped behaviour:
+  - hosted workers now receive hosted-visible orchestrator-owned WASM tool
+    definitions through the same remote catalogue as MCP tools
+  - worker-side proxy registration and reasoning-surface merging required no
+    new transport or source-aware logic because the existing path already
+    consumes canonical `ToolDefinition` values
+  - generic hosted execution now accepts eligible WASM-backed tools through the
+    same lookup and execute path as MCP-backed tools
+- 2026-04-10T20:21:00+02:00 Validation evidence:
+  - `cargo test hosted_tool --lib`
+  - `cargo test remote_tool_ --lib`
+  - `cargo test fidelity --lib`
+  - `make all`
+  - `bunx markdownlint-cli2`
+    `docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md`
+    `docs/roadmap.md`
+    `docs/rfcs/0002-expose-wasm-tool-definitions.md`
+    `docs/users-guide.md`
+    `docs/worker-orchestrator-contract.md`
+    `docs/axinite-architecture-overview.md`
+  - `git diff --check`
+- 2026-04-10T20:21:00+02:00 Lessons for `1.2.3` and `1.2.4`:
+  - the main hosted WASM contract gap was policy exposure, not transport or
+    worker plumbing
+  - the existing `rstest` integration harness was sufficient behavioural proof
+    for this slice without introducing new `rstest-bdd` scaffolding

--- a/docs/rfcs/0002-expose-wasm-tool-definitions.md
+++ b/docs/rfcs/0002-expose-wasm-tool-definitions.md
@@ -245,6 +245,60 @@ filter seam, extending its eligibility rules to include orchestrator-owned WASM
 tools, rather than reconstructing hosted visibility in a second WASM-specific
 adapter path.
 
+Figure 1. Hosted remote-tool catalogue flow for MCP and orchestrator-owned
+WASM tools.
+
+```mermaid
+classDiagram
+    class HostedToolCatalogSource {
+      <<enum>>
+      Mcp
+      Wasm
+    }
+
+    class ToolDefinition {
+      +String name
+      +String description
+      +JsonSchema parameters
+      +HostedToolCatalogSource source
+    }
+
+    class WasmToolWrapper {
+      +ToolDefinition definition
+      +HostedToolCatalogSource get_hosted_source()
+    }
+
+    class HostedToolRegistry {
+      +Vec~ToolDefinition~ hosted_tool_definitions(sources)
+      +Option~ToolDefinition~ get_hosted_tool(name)
+    }
+
+    class ApprovalPolicy {
+      +bool is_hosted_eligible(tool_definition)
+    }
+
+    class OrchestratorRemoteToolsApi {
+      +RemoteToolCatalogResponse get_remote_catalog()
+      +ExecutionResult execute_hosted_remote_tool(name, parameters)
+    }
+
+    class WorkerRemoteToolsClient {
+      +RemoteToolCatalogResponse fetch_catalog()
+      +void register_remote_proxies(catalog)
+    }
+
+    HostedToolCatalogSource <.. ToolDefinition : uses
+    WasmToolWrapper --> ToolDefinition : wraps
+    WasmToolWrapper --> HostedToolCatalogSource : reports_Wasm
+
+    HostedToolRegistry --> ToolDefinition : manages
+    HostedToolRegistry --> ApprovalPolicy : consults
+    HostedToolRegistry --> HostedToolCatalogSource : filters_by
+
+    OrchestratorRemoteToolsApi --> HostedToolRegistry : queries
+    WorkerRemoteToolsClient --> OrchestratorRemoteToolsApi : calls
+```
+
 Suggested hosted catalogue response:
 
 ```json

--- a/docs/rfcs/0002-expose-wasm-tool-definitions.md
+++ b/docs/rfcs/0002-expose-wasm-tool-definitions.md
@@ -299,6 +299,30 @@ classDiagram
     WorkerRemoteToolsClient --> OrchestratorRemoteToolsApi : calls
 ```
 
+Figure 2. Hosted worker execution flow for an advertised orchestrator-owned
+WASM tool.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Worker as Worker_container
+    participant Orchestrator as Orchestrator_execute_hosted_remote_tool
+    participant Registry as HostedToolRegistry
+
+    User->>Worker: Call_WASM_tool_via_LLM_tool_array
+    Worker->>Orchestrator: execute_hosted_remote_tool(tool_name, parameters)
+    Orchestrator->>Registry: get_hosted_tool(tool_name)
+    Registry-->>Orchestrator: ToolDefinition_or_rejection
+    alt Tool_is_hosted_safe_WASM
+        Orchestrator->>Orchestrator: Invoke_WASM_implementation()
+        Orchestrator-->>Worker: Execution_result
+        Worker-->>User: Tool_result
+    else Tool_not_visible_or_requires_approval
+        Orchestrator-->>Worker: Fail_closed_error
+        Worker-->>User: Hosted_execution_rejected
+    end
+```
+
 Suggested hosted catalogue response:
 
 ```json

--- a/docs/rfcs/0002-expose-wasm-tool-definitions.md
+++ b/docs/rfcs/0002-expose-wasm-tool-definitions.md
@@ -5,11 +5,13 @@
 - **RFC number:** 0002
 - **Status:** Proposed
 - **Created:** 2026-03-11
-- **Implementation status:** Roadmap item `1.2.1` is complete. Active WASM
-  registration paths now recover guest-exported metadata before publication,
-  warn when registration falls back to a placeholder schema, and are covered by
-  regression tests for file-loaded, storage-backed, and dev-build paths.
-  Roadmap items `1.2.2`, `1.2.3`, and `1.2.4` remain open.
+- **Implementation status:** Roadmap items `1.2.1` and `1.2.2` are complete.
+  Active WASM registration paths now recover guest-exported metadata before
+  publication, warn when registration falls back to a placeholder schema, and
+  are covered by regression tests for file-loaded, storage-backed, and
+  dev-build paths. Hosted workers now receive hosted-visible
+  orchestrator-owned WASM definitions through the shared remote-tool catalogue.
+  Roadmap items `1.2.3` and `1.2.4` remain open.
 
 ## Summary
 
@@ -130,9 +132,10 @@ The remaining problem is contractual, not structural:
 - hosted mode does not yet have a unified remote-tool catalogue for
   orchestrator-owned dynamic tools, including WASM tools
 
-Roadmap item `1.2.1` closes the first two gaps for in-process WASM tools. The
-remaining hosted-mode catalogue work is still tracked separately under
-`1.2.2`.
+Roadmap items `1.2.1` and `1.2.2` close the first two gaps for in-process and
+hosted WASM tools. The remaining work is now to demote schema-bearing retry
+hints and add the end-to-end first-call regression coverage tracked under
+`1.2.3` and `1.2.4`.
 
 ## Goals
 
@@ -234,10 +237,10 @@ The companion RFC [0001-expose-mcp-tool-definitions.md](0001-expose-mcp-tool-def
 proposes a worker-authenticated hosted tool catalogue plus generic remote tool
 execution endpoint.
 
-That same mechanism should cover orchestrator-owned active WASM tools.
+That same mechanism now covers orchestrator-owned active WASM tools.
 Roadmap item `1.1.2` is the specific prerequisite that moves hosted-visible
 catalogue filtering into the canonical `ToolRegistry` or policy layer. Roadmap
-item `1.2.2` should explicitly consume that same canonical hosted-visible
+item `1.2.2` explicitly consumes that same canonical hosted-visible
 filter seam, extending its eligibility rules to include orchestrator-owned WASM
 tools, rather than reconstructing hosted visibility in a second WASM-specific
 adapter path.
@@ -353,7 +356,7 @@ GET  /worker/{job_id}/tools/catalog
 POST /worker/{job_id}/tools/execute
 ```
 
-The catalogue should include hosted-visible active WASM tools alongside other
+The catalogue includes hosted-visible active WASM tools alongside other
 orchestrator-owned tools.
 
 ### Error interface

--- a/docs/rfcs/0002-expose-wasm-tool-definitions.md
+++ b/docs/rfcs/0002-expose-wasm-tool-definitions.md
@@ -260,7 +260,6 @@ classDiagram
       +String name
       +String description
       +JsonSchema parameters
-      +HostedToolCatalogSource source
     }
 
     class WasmToolWrapper {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,7 @@ by tightening the contract around active WASM tools.
   - Success: guest-exported metadata or explicit host overrides are applied
     during registration, and active WASM tools never rely on a failure path to
     teach the model their arguments.
-- [ ] 1.2.2. Extend the remote tool catalog to include orchestrator-owned WASM
+- [x] 1.2.2. Extend the remote tool catalog to include orchestrator-owned WASM
       tools. Requires 1.1.1 and 1.2.1.
   - See [RFC 0002 §Problem](./rfcs/0002-expose-wasm-tool-definitions.md#problem)
     and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,13 +116,13 @@ by tightening the contract around active WASM tools.
   - Success: guest-exported metadata or explicit host overrides are applied
     during registration, and active WASM tools never rely on a failure path to
     teach the model their arguments.
-- [x] 1.2.2. Extend the remote tool catalog to include orchestrator-owned WASM
+- [x] 1.2.2. Extend the remote tool catalogue to include orchestrator-owned WASM
       tools. Requires 1.1.1 and 1.2.1.
   - See [RFC 0002 §Problem](./rfcs/0002-expose-wasm-tool-definitions.md#problem)
     and
     [RFC 0002 §Migration Plan](./rfcs/0002-expose-wasm-tool-definitions.md#migration-plan).
   - Success: hosted workers receive proactive WASM definitions through the same
-    catalog path used for MCP tools, and hosted mode stops omitting
+    catalogue path used for MCP tools, and hosted mode stops omitting
     orchestrator-owned WASM tools from the tool array.
 - [ ] 1.2.3. Demote schema-bearing retry hints to fallback diagnostics. Requires
       1.2.1.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -9,8 +9,9 @@ Hosted workers now advertise two tool families to the model:
 
 - container-local development tools such as `shell`, `read_file`,
   `write_file`, `list_dir`, and `apply_patch`
-- active hosted-visible Model Context Protocol (MCP) tools fetched from the
-  worker-authenticated remote catalogue at startup
+- active hosted-visible orchestrator-owned tools fetched from the
+  worker-authenticated remote catalogue at startup, including both Model
+  Context Protocol (MCP) tools and WebAssembly (WASM) tools
 
 When the worker receives the remote catalogue, it registers a local proxy for
 each advertised remote tool. The model therefore sees the orchestrator-owned
@@ -41,11 +42,11 @@ later refreshes update only the tool list and any queued follow-up prompts.
 ```
 
 The hosted-visible remote catalogue is now filtered from the canonical
-`ToolRegistry` rather than from the HTTP adapter layer. For the current MCP
-parity step, that catalogue includes only active MCP tools that are executable
-in hosted mode. Other orchestrator-owned tool families, including
-extension-management built-ins and orchestrator-owned WebAssembly (WASM) tools,
-remain outside the hosted-visible catalogue until their roadmap items land.
+`ToolRegistry` rather than from the HTTP adapter layer. That catalogue now
+includes active hosted-visible MCP tools plus active hosted-visible
+orchestrator-owned WASM tools that are executable in hosted mode.
+Extension-management built-ins and other ineligible orchestrator-owned tools
+still remain outside the hosted-visible catalogue.
 
 Not every tool in the orchestrator registry is visible in hosted mode. Tools
 may still be hidden when they:
@@ -56,8 +57,9 @@ may still be hidden when they:
 | --- | --- | --- |
 | Requires interactive approval | Hidden | Omitted from the remote catalogue because hosted workers cannot satisfy interactive approval prompts |
 | Depends on worker-local execution | Hidden | Omitted because the orchestrator cannot safely proxy a worker-local dependency |
-| Other ineligible, protected, or non-MCP cases | Hidden | Omitted from the remote catalogue and rejected if called directly |
+| Other ineligible, protected, or non-hosted-visible cases | Hidden | Omitted from the remote catalogue and rejected if called directly |
 | Active hosted-visible MCP tool | Visible | Advertised unchanged in the remote catalogue and executed through the generic remote-tool request |
+| Active hosted-visible orchestrator-owned WASM tool | Visible | Advertised unchanged in the remote catalogue and executed through the same generic remote-tool request |
 
 If a hosted-visible remote tool is selected, the worker sends one generic
 execution request to the orchestrator rather than using tool-family-specific

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -46,7 +46,7 @@ The hosted-visible remote catalogue is now filtered from the canonical
 includes active hosted-visible MCP tools plus active hosted-visible
 orchestrator-owned WASM tools that are executable in hosted mode.
 Extension-management built-ins and other ineligible orchestrator-owned tools
-still remain outside the hosted-visible catalogue.
+remain outside the hosted-visible catalogue.
 
 Not every tool in the orchestrator registry is visible in hosted mode. Tools
 may still be hidden when they:

--- a/docs/worker-orchestrator-contract.md
+++ b/docs/worker-orchestrator-contract.md
@@ -152,5 +152,13 @@ Hosted remote tools use a parallel mechanism:
 3. The runtime merges those definitions into the reasoning context alongside
    container-local tools.
 
+The orchestrator-owned portion of that hosted catalogue is now source-agnostic
+at the wire level. Hosted-visible MCP tools and hosted-visible
+orchestrator-owned WASM tools travel through the same `GET
+/worker/{job_id}/tools/catalog` route and execute through the same `POST
+/worker/{job_id}/tools/execute` route, while the registry-owned hosted
+visibility policy continues to filter out protected, approval-gated, and other
+ineligible tools before advertisement.
+
 The shared route constants and transport types are what keep that hosted tool
 surface consistent across the sandbox boundary.

--- a/docs/worker-orchestrator-contract.md
+++ b/docs/worker-orchestrator-contract.md
@@ -153,8 +153,9 @@ Hosted remote tools use a parallel mechanism:
    container-local tools.
 
 The orchestrator-owned portion of that hosted catalogue is now source-agnostic
-at the wire level. Hosted-visible MCP tools and hosted-visible
-orchestrator-owned WASM tools travel through the same `GET
+at the wire level. Hosted-visible Model Context Protocol (MCP) tools and
+hosted-visible orchestrator-owned WebAssembly (WASM) tools travel through the
+same `GET
 /worker/{job_id}/tools/catalog` route and execute through the same `POST
 /worker/{job_id}/tools/execute` route, while the registry-owned hosted
 visibility policy continues to filter out protected, approval-gated, and other

--- a/src/orchestrator/api/remote_tools.rs
+++ b/src/orchestrator/api/remote_tools.rs
@@ -16,7 +16,8 @@ use crate::tools::{
     HostedToolCatalogSource, HostedToolLookupError, Tool, ToolError, ToolOutput, ToolRegistry,
 };
 
-const HOSTED_REMOTE_TOOL_SOURCES: [HostedToolCatalogSource; 1] = [HostedToolCatalogSource::Mcp];
+const HOSTED_REMOTE_TOOL_SOURCES: [HostedToolCatalogSource; 2] =
+    [HostedToolCatalogSource::Mcp, HostedToolCatalogSource::Wasm];
 
 /// Request context for executing a hosted-eligible remote tool.
 ///

--- a/src/orchestrator/api/tests/fixtures/remote_tool_mocks.rs
+++ b/src/orchestrator/api/tests/fixtures/remote_tool_mocks.rs
@@ -51,6 +51,17 @@ impl StubTool {
             output: StubOutput::EchoParams,
         }
     }
+
+    pub(crate) fn hosted_wasm(
+        name: &'static str,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self {
+            catalog_source: Some(HostedToolCatalogSource::Wasm),
+            ..Self::hosted(name, description, parameters)
+        }
+    }
 }
 
 impl NativeTool for StubTool {
@@ -108,6 +119,7 @@ impl NativeTool for StubTool {
 pub(crate) enum ToolFixture {
     CatalogAlpha,
     CatalogBeta,
+    CatalogWasm,
     ApprovalGated,
     ContainerOnly,
 }
@@ -134,6 +146,15 @@ pub(crate) fn build_tool_fixture(kind: ToolFixture) -> Arc<dyn Tool> {
                 "type":"object",
                 "properties":{"path":{"type":"string"}},
                 "required":["path"]
+            }),
+        )) as Arc<dyn Tool>,
+        ToolFixture::CatalogWasm => Arc::new(StubTool::hosted_wasm(
+            "remote_tool_catalog_fixture_wasm",
+            "Hosted-safe WASM tool for catalog tests",
+            serde_json::json!({
+                "type":"object",
+                "properties":{"repository":{"type":"string","description":"repository name"}},
+                "required":["repository"]
             }),
         )) as Arc<dyn Tool>,
         ToolFixture::ApprovalGated => Arc::new(StubTool {

--- a/src/orchestrator/api/tests/fixtures/remote_tool_mocks.rs
+++ b/src/orchestrator/api/tests/fixtures/remote_tool_mocks.rs
@@ -113,9 +113,9 @@ impl NativeTool for StubTool {
 #[derive(Clone, Copy, Debug)]
 /// Shared hosted-remote-tool fixture presets for catalogue and execute tests.
 ///
-/// `CatalogAlpha` and `CatalogBeta` model hosted-safe catalogue entries,
-/// `ApprovalGated` models a hosted tool that must never execute without
-/// approval, and `ContainerOnly` models a non-catalogue container tool.
+/// `CatalogAlpha`, `CatalogBeta`, and `CatalogWasm` model hosted-safe
+/// catalogue entries. `ApprovalGated` models a hosted tool that must never
+/// execute without approval.
 pub(crate) enum ToolFixture {
     CatalogAlpha,
     CatalogBeta,

--- a/src/orchestrator/api/tests/remote_tools.rs
+++ b/src/orchestrator/api/tests/remote_tools.rs
@@ -25,6 +25,9 @@ async fn populate_catalog_visibility_fixtures(tools: &ToolRegistry) {
         .register(build_tool_fixture(ToolFixture::CatalogAlpha))
         .await;
     tools
+        .register(build_tool_fixture(ToolFixture::CatalogWasm))
+        .await;
+    tools
         .register(Arc::new(StubTool {
             name: "hosted_extension_catalog_builtin",
             description: "Hosted-safe extension-management built-in".to_string(),
@@ -81,6 +84,18 @@ fn expected_catalog_fixture_definition() -> crate::llm::ToolDefinition {
     }
 }
 
+fn expected_catalog_wasm_fixture_definition() -> crate::llm::ToolDefinition {
+    crate::llm::ToolDefinition {
+        name: "remote_tool_catalog_fixture_wasm".to_string(),
+        description: "Hosted-safe WASM tool for catalog tests".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"repository": {"type": "string", "description": "repository name"}},
+            "required": ["repository"]
+        }),
+    }
+}
+
 #[rstest]
 #[tokio::test]
 async fn remote_tool_catalog_returns_hosted_safe_tool_definitions(test_state: OrchestratorState) {
@@ -110,12 +125,12 @@ async fn remote_tool_catalog_returns_hosted_safe_tool_definitions(test_state: Or
 
     assert_eq!(catalog.toolset_instructions, Vec::<String>::new());
     assert_ne!(catalog.catalog_version, 0);
-    assert_eq!(catalog.tools.len(), 1);
-    let tool = &catalog.tools[0];
-    let expected = expected_catalog_fixture_definition();
-    assert_eq!(tool.name, expected.name);
-    assert_eq!(tool.description, expected.description);
-    assert_eq!(tool.parameters, expected.parameters);
+    assert_eq!(catalog.tools.len(), 2);
+    let expected = vec![
+        expected_catalog_fixture_definition(),
+        expected_catalog_wasm_fixture_definition(),
+    ];
+    assert_eq!(catalog.tools, expected);
 }
 
 async fn assert_catalog_excludes_stub(excluded_stub: StubTool) {
@@ -280,6 +295,18 @@ async fn remote_tool_execute_rejects_approval_gated_tools(test_state: Orchestrat
     )
     .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[rstest]
+#[tokio::test]
+async fn remote_tool_execute_allows_hosted_wasm_tools(test_state: OrchestratorState) {
+    let status = execute_remote_tool_status(
+        test_state,
+        build_tool_fixture(ToolFixture::CatalogWasm),
+        "remote_tool_catalog_fixture_wasm",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
 }
 
 #[rstest]

--- a/src/orchestrator/api/tests/remote_tools.rs
+++ b/src/orchestrator/api/tests/remote_tools.rs
@@ -72,28 +72,39 @@ async fn populate_catalog_visibility_fixtures(tools: &ToolRegistry) {
         .await;
 }
 
-fn expected_catalog_fixture_definition() -> crate::llm::ToolDefinition {
+fn make_catalog_fixture_definition(
+    name: &str,
+    description: &str,
+    param_name: &str,
+    param_description: &str,
+) -> crate::llm::ToolDefinition {
     crate::llm::ToolDefinition {
-        name: "remote_tool_catalog_fixture".to_string(),
-        description: "Hosted-safe tool for catalog tests".to_string(),
+        name: name.to_string(),
+        description: description.to_string(),
         parameters: serde_json::json!({
             "type": "object",
-            "properties": {"query": {"type": "string", "description": "search query"}},
-            "required": ["query"]
+            "properties": {param_name: {"type": "string", "description": param_description}},
+            "required": [param_name]
         }),
     }
 }
 
+fn expected_catalog_fixture_definition() -> crate::llm::ToolDefinition {
+    make_catalog_fixture_definition(
+        "remote_tool_catalog_fixture",
+        "Hosted-safe tool for catalog tests",
+        "query",
+        "search query",
+    )
+}
+
 fn expected_catalog_wasm_fixture_definition() -> crate::llm::ToolDefinition {
-    crate::llm::ToolDefinition {
-        name: "remote_tool_catalog_fixture_wasm".to_string(),
-        description: "Hosted-safe WASM tool for catalog tests".to_string(),
-        parameters: serde_json::json!({
-            "type": "object",
-            "properties": {"repository": {"type": "string", "description": "repository name"}},
-            "required": ["repository"]
-        }),
-    }
+    make_catalog_fixture_definition(
+        "remote_tool_catalog_fixture_wasm",
+        "Hosted-safe WASM tool for catalog tests",
+        "repository",
+        "repository name",
+    )
 }
 
 #[rstest]

--- a/src/tools/registry/tests.rs
+++ b/src/tools/registry/tests.rs
@@ -310,39 +310,74 @@ async fn hosted_tool_definitions_only_include_requested_sources(
 ) {
     let registry = hosted_registry.await;
 
-    let defs = registry
+    let mcp_defs = registry
         .hosted_tool_definitions(&[HostedToolCatalogSource::Mcp])
         .await;
-    assert_eq!(defs.len(), 1);
-    assert_eq!(defs[0].name, "mcp_visible");
-    assert_eq!(defs[0].description, "Hosted-visible MCP tool");
-    assert_eq!(defs[0].parameters, serde_json::json!({}));
+    assert_eq!(mcp_defs.len(), 1);
+    assert_eq!(mcp_defs[0].name, "mcp_visible");
+    assert_eq!(mcp_defs[0].description, "Hosted-visible MCP tool");
+    assert_eq!(mcp_defs[0].parameters, serde_json::json!({}));
+
+    let wasm_defs = registry
+        .hosted_tool_definitions(&[HostedToolCatalogSource::Wasm])
+        .await;
+    assert_eq!(wasm_defs.len(), 1);
+    assert_eq!(wasm_defs[0].name, "wasm_visible");
+    assert_eq!(wasm_defs[0].description, "Hosted-visible WASM tool");
+    assert_eq!(wasm_defs[0].parameters, serde_json::json!({}));
+
+    let mixed_defs = registry
+        .hosted_tool_definitions(&[HostedToolCatalogSource::Mcp, HostedToolCatalogSource::Wasm])
+        .await;
+    assert_eq!(
+        mixed_defs
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["mcp_visible", "wasm_visible"]
+    );
 }
 
 #[rstest]
-#[case("mcp_visible", HostedLookupExpectation::Ok)]
+#[case(
+    "mcp_visible",
+    &[HostedToolCatalogSource::Mcp][..],
+    HostedLookupExpectation::Ok
+)]
+#[case(
+    "wasm_visible",
+    &[HostedToolCatalogSource::Wasm][..],
+    HostedLookupExpectation::Ok
+)]
+#[case(
+    "wasm_visible",
+    &[HostedToolCatalogSource::Mcp, HostedToolCatalogSource::Wasm][..],
+    HostedLookupExpectation::Ok
+)]
 #[case(
     "missing_tool",
+    &[HostedToolCatalogSource::Mcp, HostedToolCatalogSource::Wasm][..],
     HostedLookupExpectation::Err(HostedToolLookupError::NotFound)
 )]
 #[case(
     "mcp_gated",
+    &[HostedToolCatalogSource::Mcp, HostedToolCatalogSource::Wasm][..],
     HostedLookupExpectation::Err(HostedToolLookupError::ApprovalGated)
 )]
 #[case(
     "wasm_visible",
+    &[HostedToolCatalogSource::Mcp][..],
     HostedLookupExpectation::Err(HostedToolLookupError::Ineligible)
 )]
 #[tokio::test]
 async fn get_hosted_tool_reports_lookup_reason(
     #[future] hosted_registry: ToolRegistry,
     #[case] name: &'static str,
+    #[case] allowed_sources: &[HostedToolCatalogSource],
     #[case] expected: HostedLookupExpectation,
 ) {
     let registry = hosted_registry.await;
-    let result = registry
-        .get_hosted_tool(name, &[HostedToolCatalogSource::Mcp])
-        .await;
+    let result = registry.get_hosted_tool(name, allowed_sources).await;
 
     match expected {
         HostedLookupExpectation::Ok => assert!(result.is_ok(), "expected Ok for {name}"),

--- a/src/worker/container/tests/hosted_fidelity.rs
+++ b/src/worker/container/tests/hosted_fidelity.rs
@@ -27,11 +27,12 @@ pub struct HostedCatalogHarness {
     pub server: tokio::task::JoinHandle<()>,
 }
 
-fn complex_orchestrator_tool_definition() -> ToolDefinition {
+fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
     crate::test_support::build_complex_tool_definition(
-        "complex_fidelity_fixture",
+        "complex_orchestrator_wasm_fidelity_fixture",
         concat!(
-            "A **complex** tool for end-to-end fidelity testing. ",
+            "A **complex** orchestrator-owned WASM tool for end-to-end fidelity ",
+            "testing. ",
             "Handles UTF-8: \u{1F680}\u{1F4A1}. ",
             "Supports `inline code` and [markdown](https://example.com). ",
             "Special chars: <>&\"'{}[]()."
@@ -44,7 +45,7 @@ async fn remote_tool_catalog_with_complex_tool(
     Path(_job_id): Path<Uuid>,
 ) -> Json<RemoteToolCatalogResponse> {
     Json(RemoteToolCatalogResponse {
-        tools: vec![complex_orchestrator_tool_definition()],
+        tools: vec![complex_orchestrator_wasm_tool_definition()],
         toolset_instructions: vec![],
         catalog_version: 99,
     })
@@ -84,7 +85,7 @@ async fn hosted_worker_proxy_definition_matches_orchestrator_canonical_definitio
 
     let proxy_tool = runtime
         .tools
-        .get("complex_fidelity_fixture")
+        .get("complex_orchestrator_wasm_fidelity_fixture")
         .await
         .expect("complex tool proxy should be registered");
 
@@ -94,7 +95,7 @@ async fn hosted_worker_proxy_definition_matches_orchestrator_canonical_definitio
         parameters: proxy_tool.parameters_schema(),
     };
 
-    let expected = complex_orchestrator_tool_definition();
+    let expected = complex_orchestrator_wasm_tool_definition();
 
     assert_eq!(
         proxy_definition, expected,

--- a/src/worker/container/tests/remote_tools.rs
+++ b/src/worker/container/tests/remote_tools.rs
@@ -19,25 +19,37 @@ use crate::worker::container::{
     HOSTED_GUIDANCE_HEADING, WorkerConfig, WorkerHttpClient, WorkerRuntime,
 };
 
-fn expected_remote_tool_definition() -> ToolDefinition {
+fn make_tool_definition(
+    name: &str,
+    description: &str,
+    parameters: serde_json::Value,
+) -> ToolDefinition {
     ToolDefinition {
-        name: "hosted_worker_remote_tool_fixture".to_string(),
-        description: "Remote tool from orchestrator catalog".to_string(),
-        parameters: serde_json::json!({
+        name: name.to_string(),
+        description: description.to_string(),
+        parameters,
+    }
+}
+
+fn expected_remote_tool_definition() -> ToolDefinition {
+    make_tool_definition(
+        "hosted_worker_remote_tool_fixture",
+        "Remote tool from orchestrator catalog",
+        serde_json::json!({
             "type": "object",
             "properties": {
                 "query": {"type": "string"}
             },
             "required": ["query"]
         }),
-    }
+    )
 }
 
 fn expected_remote_wasm_tool_definition() -> ToolDefinition {
-    ToolDefinition {
-        name: "hosted_worker_remote_wasm_tool_fixture".to_string(),
-        description: "Remote WASM tool from orchestrator catalog".to_string(),
-        parameters: serde_json::json!({
+    make_tool_definition(
+        "hosted_worker_remote_wasm_tool_fixture",
+        "Remote WASM tool from orchestrator catalog",
+        serde_json::json!({
             "type": "object",
             "properties": {
                 "repository": {"type": "string"},
@@ -45,7 +57,7 @@ fn expected_remote_wasm_tool_definition() -> ToolDefinition {
             },
             "required": ["repository"]
         }),
-    }
+    )
 }
 
 fn expected_merged_tool_names() -> Vec<String> {

--- a/src/worker/container/tests/remote_tools.rs
+++ b/src/worker/container/tests/remote_tools.rs
@@ -33,9 +33,25 @@ fn expected_remote_tool_definition() -> ToolDefinition {
     }
 }
 
+fn expected_remote_wasm_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "hosted_worker_remote_wasm_tool_fixture".to_string(),
+        description: "Remote WASM tool from orchestrator catalog".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "repository": {"type": "string"},
+                "include_private": {"type": "boolean", "default": false}
+            },
+            "required": ["repository"]
+        }),
+    }
+}
+
 fn expected_merged_tool_names() -> Vec<String> {
     let mut names = expected_local_tool_names();
     names.push(expected_remote_tool_definition().name);
+    names.push(expected_remote_wasm_tool_definition().name);
     names.sort();
     names
 }
@@ -55,7 +71,10 @@ async fn remote_tool_catalog(
     Path(_job_id): Path<Uuid>,
 ) -> Json<RemoteToolCatalogResponse> {
     Json(RemoteToolCatalogResponse {
-        tools: vec![expected_remote_tool_definition()],
+        tools: vec![
+            expected_remote_tool_definition(),
+            expected_remote_wasm_tool_definition(),
+        ],
         toolset_instructions: vec!["Prefer hosted remote tools for external systems.".to_string()],
         catalog_version: 42,
     })
@@ -146,6 +165,19 @@ async fn hosted_worker_remote_tool_catalog_registers_remote_tools()
     assert_eq!(remote_tool.description(), expected.description);
     assert_eq!(remote_tool.parameters_schema(), expected.parameters);
 
+    let remote_wasm_tool = runtime
+        .tools
+        .get("hosted_worker_remote_wasm_tool_fixture")
+        .await
+        .expect("hosted remote WASM tool should be registered");
+    let expected_wasm = expected_remote_wasm_tool_definition();
+    assert_eq!(remote_wasm_tool.name(), expected_wasm.name);
+    assert_eq!(remote_wasm_tool.description(), expected_wasm.description);
+    assert_eq!(
+        remote_wasm_tool.parameters_schema(),
+        expected_wasm.parameters
+    );
+
     server.abort();
     let _ = server.await;
     Ok(())
@@ -196,6 +228,15 @@ async fn worker_runtime_build_reasoning_context_merges_local_and_remote_tools()
     let expected = expected_remote_tool_definition();
     assert_eq!(remote_tool.description, expected.description);
     assert_eq!(remote_tool.parameters, expected.parameters);
+
+    let remote_wasm_tool = reason_ctx
+        .available_tools
+        .iter()
+        .find(|tool| tool.name == "hosted_worker_remote_wasm_tool_fixture")
+        .expect("reasoning context should expose the hosted remote WASM tool");
+    let expected_wasm = expected_remote_wasm_tool_definition();
+    assert_eq!(remote_wasm_tool.description, expected_wasm.description);
+    assert_eq!(remote_wasm_tool.parameters, expected_wasm.parameters);
 
     server.abort();
     let _ = server.await;


### PR DESCRIPTION
## Summary

- extend the hosted remote-tool catalogue to include hosted-visible orchestrator-owned WASM tools through the existing worker-orchestrator transport
- add registry, orchestrator, and worker regression coverage for mixed MCP/WASM catalogue visibility, hosted execution, and proxy-definition fidelity
- update the roadmap, RFC 0002, users guide, architecture docs, and ExecPlan to reflect the shipped hosted WASM catalogue behaviour

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [x] `cargo test hosted_tool --lib`
- [x] `cargo test remote_tool_ --lib`
- [x] `cargo test fidelity --lib`
- [x] `make all`
- [x] `bunx markdownlint-cli2 docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md docs/roadmap.md docs/rfcs/0002-expose-wasm-tool-definitions.md docs/users-guide.md docs/worker-orchestrator-contract.md docs/axinite-architecture-overview.md`
- [x] `git diff --check`

## Security Impact

Low. The feature broadens advertisement only for tools that already satisfy the hosted-visible registry policy, while approval-gated, protected, and other ineligible tools remain filtered or rejected.

## Database Impact

None

## Blast Radius

Touches the hosted remote-tool catalogue policy, related worker/orchestrator tests, and the associated documentation describing hosted WASM tool visibility.

## Rollback Plan

Revert commit `0beb083` to restore the previous MCP-only hosted catalogue behaviour.

---

**Review track**: B (feature/tests/docs)

## Summary by Sourcery

Extend the hosted remote-tool catalogue so hosted workers receive orchestrator-owned WASM tool definitions through the same path as MCP tools, with regression coverage and documentation updates for the shipped behaviour.