### PR TITLE
[codex] Add first-call WASM schema regression coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,10 @@ docker = ["dep:bollard"]
 name = "html_to_markdown"
 required-features = ["html-to-markdown"]
 
+[[test]]
+name = "e2e_traces"
+required-features = ["test-helpers"]
+
 [profile.dev.package."*"]
 debug = "line-tables-only"    # Faster linking; full info via CARGO_PROFILE_DEV_DEBUG=2
 split-debuginfo = "unpacked"  # Avoid bundling debug info into binaries

--- a/docs/axinite-architecture-overview.md
+++ b/docs/axinite-architecture-overview.md
@@ -370,8 +370,10 @@ Other edges are more muddled and currently create avoidable maintenance cost.
   discovery, MCP, WASM runtime, channel activation, secrets, database-backed
   state, and gateway callback machinery.
 - The worker-orchestrator seam now shares its hosted remote-tool contract and
-  canonical catalogue filter, but later roadmap work still needs to extend that
-  filter to WASM tools and add refresh behaviour.
+  canonical catalogue filter, and the first hosted
+  `complete_with_tools` request now preserves advertised MCP and WASM schemas
+  before execution. Later roadmap work still focuses on richer refresh
+  behaviour.
 - Job lifecycle semantics are split between in-memory context transitions and
   best-effort persistence paths, which makes cancellation and terminal status
   handling harder to reason about under failure.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -142,6 +142,9 @@
   - [Demote schema-bearing retry hints to fallback diagnostics](execplans/1-2-3-demote-schema-bearing-retry-hints.md)
     plans roadmap item `1.2.3` for making WebAssembly (WASM) retry hints
     supplemental diagnostics rather than the primary tool contract.
+  - [Add end-to-end tests for first-call WASM schema exposure](execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md)
+    plans roadmap item `1.2.4` for proving that proactive WebAssembly (WASM)
+    schema publication reaches the first hosted and non-hosted requests.
 
 ## RFCs
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -381,121 +381,6 @@ labels, truncation rules, or input set needs to change. Do not use it as
 a primary schema-transport mechanism: the canonical schema remains the
 advertised `ToolDefinition.parameters` value.
 
-### End-to-end WASM schema regression tests
-
-The `e2e_traces` integration test target includes first-call WASM schema
-regression tests introduced in roadmap item `1.2.4`. These tests live in
-`tests/e2e_traces/wasm_schema_exposure.rs` and require the `test-helpers`
-feature because they import `ironclaw::testing::github_wasm_wrapper`.
-
-#### Running the e2e_traces tests
-
-```bash
-# Compile and run the full e2e_traces suite (test-helpers required):
-cargo nextest run --test e2e_traces --features test-helpers
-
-# Run only the WASM schema exposure tests:
-cargo nextest run --test e2e_traces --features test-helpers \
-  -E 'test(wasm_schema)'
-
-# Verify the target is skipped cleanly without the feature:
-cargo check --all --benches --tests --examples
-```
-
-`Cargo.toml` declares `required-features = ["test-helpers"]` for the
-`e2e_traces` test target, so Cargo skips it gracefully when the feature is
-absent rather than emitting a compile error.
-
-#### CapturingToolLlm — non-hosted schema verification
-
-For in-process (non-hosted) schema assertions, implement
-`ironclaw::llm::NativeLlmProvider` as a capturing stub that records every
-`ToolCompletionRequest` before returning a deterministic response:
-
-```rust
-use ironclaw::llm::{NativeLlmProvider, ToolCompletionRequest};
-
-#[derive(Default)]
-struct CapturingToolLlm {
-    requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
-}
-
-impl NativeLlmProvider for CapturingToolLlm {
-    // … implement model_name, cost_per_token, complete …
-
-    async fn complete_with_tools(
-        &self,
-        request: ToolCompletionRequest,
-    ) -> Result<ToolCompletionResponse, LlmError> {
-        self.requests.lock().await.push(request);
-        // Return a stub response — no tool calls, no side effects.
-        Ok(ToolCompletionResponse { … })
-    }
-}
-```
-
-Pass the capturing LLM into `TestRigBuilder::with_llm(…)` and inspect
-`requests` after the first response to assert schema fidelity before any tool
-execution occurs.
-
-#### HostedCatalogHarness — hosted schema verification
-
-For the hosted (worker-proxied) path, `HostedCatalogHarness` in
-`src/worker/container/tests/hosted_fidelity.rs` spins up a real Axum server
-that:
-
-- serves a controlled `RemoteToolCatalogResponse` at the catalogue route,
-- captures every `ProxyToolCompletionRequest` posted to
-  `LLM_COMPLETE_WITH_TOOLS_ROUTE`.
-
-Obtain it via the `hosted_catalog_harness` rstest fixture:
-
-```rust
-#[rstest]
-#[tokio::test]
-async fn my_schema_test(
-    #[future] hosted_catalog_harness: Result<HostedCatalogHarness, Box<dyn std::error::Error>>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let HostedCatalogHarness { runtime, server, captured_requests } =
-        hosted_catalog_harness.await?;
-
-    runtime.register_remote_tools().await?;
-    // … drive the worker …
-
-    let requests = captured_requests.lock().await;
-    let first = requests.first().expect("expected a proxied request");
-    // Assert schema fidelity on first.tools …
-
-    server.abort();
-    let _ = server.await;
-    Ok(())
-}
-```
-
-Always abort and await the server join handle at the end of the test to avoid
-port leaks between test runs.
-
-#### Schema verification pattern
-
-Both harnesses use the same assertion idiom to confirm that the first
-tool-capable request carries the registered schema rather than the placeholder:
-
-```rust
-assert_ne!(
-    tool.parameters,
-    serde_json::json!({
-        "type": "object",
-        "properties": {},
-        "additionalProperties": true
-    }),
-    "first request must not fall back to the placeholder WASM schema"
-);
-assert_eq!(
-    tool, &expected_definition,
-    "the first LLM request must carry the schema advertised at registration time"
-);
-```
-
 ## When to use cargo test versus cargo-nextest
 
 Today:
@@ -639,6 +524,116 @@ its own exported metadata.
 The storage path is the one that exercises schema normalization, because
 backends may persist placeholder or null schemas that must be stripped
 before the guest-export recovery logic can run.
+
+## End-to-end WASM schema regression tests
+
+The `e2e_traces` integration test target includes first-call WASM schema
+regression tests introduced in roadmap item `1.2.4`. These tests live in
+`tests/e2e_traces/wasm_schema_exposure.rs` and require the `test-helpers`
+feature because they import `ironclaw::testing::github_wasm_wrapper`.
+
+`Cargo.toml` declares `required-features = ["test-helpers"]` for the
+`e2e_traces` target, so Cargo skips it gracefully when the feature is
+absent rather than emitting a compile error.
+
+### Running the tests
+
+```bash
+# Compile and run the full e2e_traces suite:
+cargo nextest run --test e2e_traces --features test-helpers
+
+# Run only the WASM schema exposure tests:
+cargo nextest run --test e2e_traces --features test-helpers \
+  -E 'test(wasm_schema)'
+
+# Verify the target is skipped cleanly without the feature:
+cargo check --all --benches --tests --examples
+```
+
+### CapturingToolLlm — non-hosted schema verification
+
+For in-process (non-hosted) schema assertions, implement
+`ironclaw::llm::NativeLlmProvider` as a capturing stub that records every
+`ToolCompletionRequest` before returning a deterministic response:
+
+```rust
+#[derive(Default)]
+struct CapturingToolLlm {
+    requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
+}
+
+#[async_trait]
+impl NativeLlmProvider for CapturingToolLlm {
+    async fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.requests.lock().await.push(request);
+        Ok(ToolCompletionResponse { /* deterministic stub */ })
+    }
+    // … remaining required methods …
+}
+```
+
+Pass the capturing LLM into `TestRigBuilder::with_llm(…)` and inspect
+`requests` after the first response to assert schema fidelity before any
+tool execution occurs.
+
+### HostedCatalogHarness — hosted schema verification
+
+For the hosted (worker-proxied) path, `HostedCatalogHarness` in
+`src/worker/container/tests/hosted_fidelity.rs` spins up a real Axum
+server that:
+
+- serves a controlled `RemoteToolCatalogResponse` at the catalogue route,
+- captures every `ProxyToolCompletionRequest` posted to
+  `LLM_COMPLETE_WITH_TOOLS_ROUTE`.
+
+Obtain it via the `hosted_catalog_harness` rstest fixture:
+
+```rust
+#[rstest]
+#[tokio::test]
+async fn my_schema_test(
+    #[future] hosted_catalog_harness: Result<HostedCatalogHarness, Box<dyn Error>>,
+) -> Result<(), Box<dyn Error>> {
+    let harness = hosted_catalog_harness.await?;
+
+    harness.runtime.register_remote_tools().await?;
+    // … drive the worker …
+
+    let requests = harness.captured_requests.lock().await;
+    let first = requests.first().expect("expected a proxied request");
+    // Assert schema fidelity on first.tools …
+
+    harness.server.abort();
+    let _ = harness.server.await;
+    Ok(())
+}
+```
+
+Always abort and await the server join handle at the end of the test to
+avoid port leaks between test runs.
+
+### Schema verification pattern
+
+Both harnesses use the same assertion idiom:
+
+```rust
+assert_ne!(
+    tool.parameters,
+    serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true
+    }),
+    "first request must not fall back to the placeholder WASM schema"
+);
+assert_eq!(
+    tool, &expected_definition,
+    "the first LLM request must carry the schema advertised at registration time"
+);
+```
 
 ## Expected follow-up changes
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -381,6 +381,121 @@ labels, truncation rules, or input set needs to change. Do not use it as
 a primary schema-transport mechanism: the canonical schema remains the
 advertised `ToolDefinition.parameters` value.
 
+### End-to-end WASM schema regression tests
+
+The `e2e_traces` integration test target includes first-call WASM schema
+regression tests introduced in roadmap item `1.2.4`. These tests live in
+`tests/e2e_traces/wasm_schema_exposure.rs` and require the `test-helpers`
+feature because they import `ironclaw::testing::github_wasm_wrapper`.
+
+#### Running the e2e_traces tests
+
+```bash
+# Compile and run the full e2e_traces suite (test-helpers required):
+cargo nextest run --test e2e_traces --features test-helpers
+
+# Run only the WASM schema exposure tests:
+cargo nextest run --test e2e_traces --features test-helpers \
+  -E 'test(wasm_schema)'
+
+# Verify the target is skipped cleanly without the feature:
+cargo check --all --benches --tests --examples
+```
+
+`Cargo.toml` declares `required-features = ["test-helpers"]` for the
+`e2e_traces` test target, so Cargo skips it gracefully when the feature is
+absent rather than emitting a compile error.
+
+#### CapturingToolLlm — non-hosted schema verification
+
+For in-process (non-hosted) schema assertions, implement
+`ironclaw::llm::NativeLlmProvider` as a capturing stub that records every
+`ToolCompletionRequest` before returning a deterministic response:
+
+```rust
+use ironclaw::llm::{NativeLlmProvider, ToolCompletionRequest};
+
+#[derive(Default)]
+struct CapturingToolLlm {
+    requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
+}
+
+impl NativeLlmProvider for CapturingToolLlm {
+    // … implement model_name, cost_per_token, complete …
+
+    async fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.requests.lock().await.push(request);
+        // Return a stub response — no tool calls, no side effects.
+        Ok(ToolCompletionResponse { … })
+    }
+}
+```
+
+Pass the capturing LLM into `TestRigBuilder::with_llm(…)` and inspect
+`requests` after the first response to assert schema fidelity before any tool
+execution occurs.
+
+#### HostedCatalogHarness — hosted schema verification
+
+For the hosted (worker-proxied) path, `HostedCatalogHarness` in
+`src/worker/container/tests/hosted_fidelity.rs` spins up a real Axum server
+that:
+
+- serves a controlled `RemoteToolCatalogResponse` at the catalogue route,
+- captures every `ProxyToolCompletionRequest` posted to
+  `LLM_COMPLETE_WITH_TOOLS_ROUTE`.
+
+Obtain it via the `hosted_catalog_harness` rstest fixture:
+
+```rust
+#[rstest]
+#[tokio::test]
+async fn my_schema_test(
+    #[future] hosted_catalog_harness: Result<HostedCatalogHarness, Box<dyn std::error::Error>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let HostedCatalogHarness { runtime, server, captured_requests } =
+        hosted_catalog_harness.await?;
+
+    runtime.register_remote_tools().await?;
+    // … drive the worker …
+
+    let requests = captured_requests.lock().await;
+    let first = requests.first().expect("expected a proxied request");
+    // Assert schema fidelity on first.tools …
+
+    server.abort();
+    let _ = server.await;
+    Ok(())
+}
+```
+
+Always abort and await the server join handle at the end of the test to avoid
+port leaks between test runs.
+
+#### Schema verification pattern
+
+Both harnesses use the same assertion idiom to confirm that the first
+tool-capable request carries the registered schema rather than the placeholder:
+
+```rust
+assert_ne!(
+    tool.parameters,
+    serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true
+    }),
+    "first request must not fall back to the placeholder WASM schema"
+);
+assert_eq!(
+    tool, &expected_definition,
+    "the first LLM request must carry the schema advertised at registration time"
+);
+```
+
 ## When to use cargo test versus cargo-nextest
 
 Today:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -530,7 +530,8 @@ before the guest-export recovery logic can run.
 The `e2e_traces` integration test target includes first-call WASM schema
 regression tests introduced in roadmap item `1.2.4`. These tests live in
 `tests/e2e_traces/wasm_schema_exposure.rs` and require the `test-helpers`
-feature because they import `ironclaw::testing::github_wasm_wrapper`.
+feature because they import the GitHub test helper
+`ironclaw::testing::github_wasm_wrapper`.
 
 `Cargo.toml` declares `required-features = ["test-helpers"]` for the
 `e2e_traces` target, so Cargo skips it gracefully when the feature is
@@ -562,7 +563,6 @@ struct CapturingToolLlm {
     requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
 }
 
-#[async_trait]
 impl NativeLlmProvider for CapturingToolLlm {
     async fn complete_with_tools(
         &self,

--- a/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
+++ b/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
@@ -1,0 +1,471 @@
+# Add end-to-end tests for first-call WASM schema exposure
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`,
+`Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `1.2.4` exists to prove the contract established by `1.2.1`,
+`1.2.2`, and `1.2.3`: active WebAssembly (WASM) tools must expose their
+advertised schema to the large language model (LLM) before the first tool call
+in both non-hosted and hosted flows. The failure mode this plan must prevent is
+silent regression back to a failure-first contract where the model only learns
+WASM arguments after a bad call and a retry hint.
+
+After this work, the test suite must fail loudly if either of the following
+regressions returns:
+
+1. A first reasoning request containing an active WASM tool omits that tool's
+   advertised `ToolDefinition.parameters` schema or falls back to the
+   placeholder schema shape.
+2. A hosted worker advertises or forwards orchestrator-owned WASM tools without
+   their proactive schema, or can only recover after a schema-bearing failure
+   hint.
+
+Success is observable in four ways. First, targeted tests prove that the first
+LLM request in the in-process path includes the advertised schema for an active
+WASM tool before any execution attempt. Second, targeted hosted-path tests
+prove that the worker's first proxied tool-capable completion request includes
+the same advertised schema for orchestrator-owned WASM tools fetched from the
+remote catalogue. Third, unhappy-path tests still show retry guidance as
+supplemental diagnostics that point back to the already advertised schema.
+Fourth, `make all` passes and the roadmap entry for `1.2.4` is marked done.
+
+This plan uses the `hexagonal-architecture` guidance narrowly. Contract policy
+belongs in inward-facing seams such as WASM registration, registry projection,
+reasoning-context assembly, and the worker-orchestrator transport types.
+Adapters such as the orchestrator HTTP handlers and worker runtime may expose
+and verify that policy, but must not invent a second WASM-specific contract.
+
+## Approval gates
+
+- Plan approved
+  Acceptance criteria: the implementation stays scoped to tests, narrowly
+  supporting test harnesses, and documentation updates for roadmap item
+  `1.2.4`. No new runtime contract, no new transport route, and no broadened
+  provider-shaping work.
+  Sign-off: human reviewer approves this ExecPlan before implementation
+  begins.
+
+- Implementation complete
+  Acceptance criteria: non-hosted and hosted first-call schema exposure are
+  both covered by observable regression tests, unhappy paths remain covered,
+  and relevant documentation is synchronized.
+  Sign-off: implementer marks all milestones complete before final validation.
+
+- Validation passed
+  Acceptance criteria: targeted tests, `make all`, Markdown linting for changed
+  docs, and `git diff --check` all pass with retained logs.
+  Sign-off: implementer records evidence immediately before commit.
+
+- Docs synced
+  Acceptance criteria: `docs/roadmap.md`, `docs/rfcs/0002...`,
+  `docs/users-guide.md`, `docs/worker-orchestrator-contract.md`, and
+  `docs/axinite-architecture-overview.md` describe the same first-call WASM
+  contract, and `docs/contents.md` indexes this plan.
+  Sign-off: implementer completes documentation updates as the final
+  pre-commit checkpoint.
+
+## Repository orientation
+
+The files below are the authoritative orientation points for this feature.
+
+- `docs/roadmap.md` defines `1.2.4`, its dependencies on `1.2.2` and `1.2.3`,
+  and the success condition that both hosted and non-hosted paths fail if
+  proactive schema publication regresses.
+- `docs/rfcs/0002-expose-wasm-tool-definitions.md` is the design authority.
+  The most important sections are `Goals`, `Detailed Interface`,
+  `Testing Strategy`, and `Migration Plan` step 5.
+- `docs/execplans/1-2-1-audit-and-fix-wasm-registration-paths.md`,
+  `docs/execplans/1-2-2-orchestrator-owned-wasm-tools-in-tool-catalogue.md`,
+  and `docs/execplans/1-2-3-demote-schema-bearing-retry-hints.md` capture the
+  decisions already made for registration-time schema publication, hosted
+  catalogue reuse, and fallback-only retry hints.
+- `src/tools/wasm/loader.rs` already contains registration-path regression
+  tests such as
+  `load_from_files_publishes_guest_schema_in_tool_definitions` and
+  `load_dev_tools_publishes_guest_schema_in_tool_definitions`. Those tests are
+  the unit-level proof that active WASM registrations publish real schemas.
+- `src/tools/wasm/wrapper.rs` and `src/tools/wasm/wrapper/metadata.rs` own the
+  fallback-diagnostic path. The first-call tests must prove that this path is
+  supplemental rather than primary.
+- `src/tools/registry/hosted.rs` is the canonical hosted-visible policy seam.
+  Hosted-path tests must keep this registry-owned filter as the source of truth
+  instead of rebuilding selection logic in the orchestrator adapter or the
+  worker runtime.
+- `src/orchestrator/api/remote_tools.rs`,
+  `src/orchestrator/api/handlers.rs`, and
+  `src/orchestrator/api/tests/{remote_tools.rs,catalogue_fidelity.rs,transport_parity.rs}`
+  own hosted catalogue construction, the shared transport boundary, and current
+  fidelity tests.
+- `src/worker/container.rs`, `src/worker/container/delegate.rs`, and
+  `src/worker/container/tests/{remote_tools.rs,hosted_fidelity.rs}` own worker
+  proxy registration, first reasoning-context assembly, later
+  `available_tools` refresh, and the current hosted round-trip tests.
+- `src/worker/api.rs` and `src/worker/api/proxy_types.rs` define the
+  tool-capable proxied completion request. This is the precise place where the
+  hosted first-call request can be observed without adding a new transport.
+- `tests/e2e_traces/worker_coverage.rs` and the supporting trace rig under
+  `tests/support/test_rig/` already provide an in-process end-to-end harness
+  that can inspect captured first LLM requests through `TraceLlm`.
+- `docs/users-guide.md` and `docs/worker-orchestrator-contract.md` already
+  describe proactive schema publication as the primary contract.
+- The user request referenced `docs/axinite-architecture-summary.md`, but that
+  file does not exist in this checkout. Use
+  `docs/axinite-architecture-overview.md` as the relevant architecture
+  reference.
+
+## Constraints
+
+- Do not change the canonical LLM-facing tool shape. `ToolDefinition` must
+  remain `name`, `description`, and `parameters`.
+
+- Do not add a WASM-specific transport, a second hosted catalogue route, or a
+  second schema source for hosted workers. The existing worker-orchestrator
+  boundary must remain the only normal hosted contract.
+
+- Keep policy inward. Tests may verify registry filtering, catalogue
+  projection, reasoning-context assembly, and proxied request forwarding, but
+  adapters must not gain new WASM-specific branching that duplicates existing
+  policy.
+
+- Preserve the `1.2.1` contract that active WASM tool schemas are recovered or
+  overridden at registration time, and the `1.2.3` contract that retry hints
+  are fallback diagnostics only.
+
+- Use `rstest` fixtures for unit and integration coverage.
+
+- Use `rstest-bdd` only if one focused behaviour-driven development (BDD)
+  scenario can reuse an existing in-process harness with no disproportionate
+  new scaffolding. If that threshold is exceeded, keep the behavioural proof in
+  `rstest` integration or trace-backed tests and document the decision.
+
+- Prefer existing in-process harnesses over live external services, Docker, or
+  ambient environment mutation. Dependency injection and capturing stubs are the
+  expected patterns.
+
+- Keep new or modified files under repository size limits. If a test file would
+  exceed 400 lines, extract helpers into a nearby fixture module instead.
+
+- Update user-facing and maintainer-facing documentation in the same delivery
+  pass, including the roadmap entry once the feature lands.
+
+- Check `FEATURE_PARITY.md` during implementation and update it in the same
+  branch if a tracked feature statement becomes stale.
+
+## Tolerances (exception triggers)
+
+- Scope: if the smallest credible implementation touches more than 14 files or
+  roughly 650 net new lines before documentation, stop and verify that
+  unrelated provider, worker-refresh, or extension-runtime work has not leaked
+  into this slice.
+
+- Interface: if proving hosted first-call behaviour requires changing
+  `ToolDefinition`, `ToolCompletionRequest`, `ProxyToolCompletionRequest`, or
+  the shared route constants, stop and document why the existing contract
+  cannot express the test.
+
+- Harness growth: if capturing the first hosted `complete_with_tools` request
+  would require more than two new support files or a generic testing framework
+  that reaches beyond this roadmap item, stop and choose the smallest
+  in-process adapter-local capture seam instead.
+
+- BDD proportionality: if adding `rstest-bdd` requires a new feature file
+  family, a new runtime fixture stack, or more than one new scenario-support
+  module, document that clearly and keep the behavioural proof in `rstest`.
+
+- Ambiguity: if the current code can only prove schema presence in intermediate
+  state and not in the actual first request sent to an LLM-facing seam, stop
+  and decide explicitly whether to add a narrow capturing provider or to widen
+  an existing trace harness.
+
+- Documentation drift: if roadmap, RFC, user's guide, and internal contract
+  docs disagree about whether `1.2.4` is complete or about what counts as the
+  first-call contract, reconcile that before marking the work done.
+
+## Risks
+
+- Risk: Existing tests already cover schema publication and catalogue fidelity,
+  so new tests may accidentally duplicate current coverage without proving the
+  new first-call invariant.
+  Severity: high
+  Likelihood: medium
+  Mitigation: every new test must name the exact regression it catches that is
+  not already covered today, especially around observing the first LLM-facing
+  request rather than intermediate registry state.
+
+- Risk: Strict equality checks against full schemas may become brittle if
+  provider-safe shaping changes while the underlying contract remains valid.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: use exact equality only where fidelity is itself the contract
+  boundary, and otherwise assert the structural invariants that matter for
+  first-call correctness.
+
+- Risk: Hosted-path tests may prove only catalogue fetch or proxy registration,
+  not the actual first proxied tool-capable completion request.
+  Severity: high
+  Likelihood: medium
+  Mitigation: include one capturing hosted test that inspects the
+  `ProxyToolCompletionRequest.tools` payload sent through
+  `llm_complete_with_tools`.
+
+- Risk: The non-hosted path may drift toward testing a fake native tool instead
+  of a real WASM registration path, weakening the regression value.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: use the real GitHub WASM fixture or the existing WASM loader
+  helpers wherever practical so the first-call proof remains tied to actual
+  registration behaviour.
+
+- Risk: Documentation drift is likely because the roadmap marks `1.2.2` done
+  while its ExecPlan file still shows `IN PROGRESS`, and this feature touches
+  the same document cluster.
+  Severity: medium
+  Likelihood: high
+  Mitigation: treat documentation synchronization as its own milestone and
+  explicitly reconcile status wording before marking `1.2.4` complete.
+
+## Milestone 1: confirm the observable first-call seams
+
+Start by deciding what counts as the first request for each path and how the
+tests will observe it.
+
+1. Re-read RFC 0002 sections `Goals`, `Detailed Interface`, `Testing Strategy`,
+   and `Migration Plan` step 5 alongside the existing `1.2.1` through `1.2.3`
+   ExecPlans.
+2. For the non-hosted path, confirm that the trace-backed rig in
+   `tests/support/test_rig/` can capture the first request via
+   `TestRig::captured_llm_requests()` and that this route observes the actual
+   `ToolCompletionRequest` seen by the reasoning engine.
+3. For the hosted path, confirm the narrowest seam that can capture the first
+   proxied request without new transport work. The preferred seam is a
+   capturing orchestrator-side LLM stub exercised through
+   `POST /worker/{job_id}/llm/complete_with_tools`, because that observes the
+   worker's forwarded `tools` payload directly.
+4. Record the exact assertions for each path: schema present, schema
+   non-placeholder, and retry hints not required to learn the contract.
+
+Expected result: the implementer can point to one concrete first-request seam
+for non-hosted execution and one for hosted execution, with no ambiguity about
+what the tests must observe.
+
+## Milestone 2: extend non-hosted coverage from registration proof to first-call proof
+
+Add the non-hosted tests that close the gap between registration and actual
+request assembly.
+
+1. Keep the existing registration-path tests in `src/tools/wasm/loader.rs` as
+   the unit-level contract that real schemas enter the registry through file,
+   storage-backed, and dev-build paths.
+2. Add a trace-backed behavioural test under `tests/e2e_traces/` that builds a
+   rig with an active WASM tool and inspects the first captured LLM request.
+   The test should assert that the active WASM tool appears in the request's
+   tool list with the advertised `parameters` schema before any tool execution
+   occurs.
+3. Prefer the real GitHub WASM fixture and existing helper functions used by
+   the WASM loader tests so the behavioural proof is tied to the actual guest
+   metadata path rather than a native-tool stand-in.
+4. Add one unhappy-path assertion showing that a malformed first call still
+   yields fallback guidance that points back to the already advertised schema.
+
+Expected result: the in-process agent path now has one observable proof that
+the first LLM call already carries the active WASM schema and one proof that
+the failure path is supplemental only.
+
+## Milestone 3: extend hosted coverage from catalogue fidelity to first-call forwarding
+
+Add the hosted tests that prove the worker forwards proactive WASM schema data
+on its first tool-capable request.
+
+1. Reuse the existing hosted catalogue and worker registration tests in
+   `src/orchestrator/api/tests/remote_tools.rs`,
+   `src/orchestrator/api/tests/catalogue_fidelity.rs`,
+   `src/worker/container/tests/remote_tools.rs`, and
+   `src/worker/container/tests/hosted_fidelity.rs` as the base matrix.
+2. Introduce a capturing LLM stub or equivalent narrow helper in the
+   orchestrator API test surface that records the incoming
+   `ToolCompletionRequest` built by `llm_complete_with_tools`.
+3. Drive a worker runtime through its first hosted reasoning call and assert
+   that the forwarded `tools` vector contains the advertised orchestrator-owned
+   WASM definition with the same schema already proven at catalogue time.
+4. Keep the worker-orchestrator contract source-agnostic at the wire level.
+   The test should prove that hosted-visible Model Context Protocol (MCP) tools
+   and hosted-visible WASM tools share the same request boundary, not that WASM
+   tools have a special hosted path.
+
+Expected result: the hosted worker path now has a direct regression test for
+the first forwarded `complete_with_tools` request, not only for catalogue fetch
+and proxy registration.
+
+## Milestone 4: harden fail-closed and unhappy-path regressions
+
+Use focused tests to prevent regressions that would reintroduce failure-first
+teaching or weaken hosted safety behaviour.
+
+1. Add or extend tests that fail if a first-call path carries a placeholder
+   schema instead of the advertised one.
+2. Keep hosted visibility and execution rejection in sync with the canonical
+   registry policy. Ineligible, protected, or approval-gated tools must remain
+   hidden or rejected even though active hosted-visible WASM tools are present.
+3. Keep the `1.2.3` contract intact by asserting that fallback guidance still
+   references the advertised schema rather than becoming the primary contract.
+4. Avoid duplicate assertions across orchestrator, worker, and trace-backed
+   tests. Each new test should protect a distinct seam: registration,
+   forwarding, or unhappy-path recovery.
+
+Expected result: both happy and unhappy paths fail closed in the way RFC 0002
+intends, and the test matrix distinguishes contract loss from normal tool
+errors.
+
+## Milestone 5: evaluate whether a focused `rstest-bdd` scenario is proportional
+
+The user asked for unit and behavioural tests, using `rstest-bdd` where
+applicable. Make the applicability decision explicit.
+
+1. Attempt to identify one scenario that would add clarity beyond the
+   trace-backed and integration tests, such as "active WASM tool is visible to
+   the model before first use".
+2. Only proceed if that scenario can reuse an existing in-process fixture stack
+   and stay within the tolerances above.
+3. If it cannot, record in `Decision Log` that `rstest-bdd` is not
+   proportional for this slice because the existing `rstest` and trace-backed
+   harnesses already provide more direct observability of the first request.
+
+Expected result: the plan either includes one deliberately small BDD scenario
+or documents why `rstest` provides the proportionate behavioural layer here.
+
+## Milestone 6: synchronize documentation and close the roadmap item
+
+Update the documents that define or summarize the contract once the tests land.
+
+1. Update `docs/roadmap.md` to mark `1.2.4` done only after the test evidence
+   exists.
+2. Update `docs/rfcs/0002-expose-wasm-tool-definitions.md` implementation
+   status so it says first-call end-to-end regression coverage is complete.
+3. Review `docs/users-guide.md` and
+   `docs/worker-orchestrator-contract.md` for wording about proactive schema
+   publication and fallback diagnostics. Update only if the implementation or
+   current wording has drifted.
+4. Review `docs/axinite-architecture-overview.md` for any maintainer-facing
+   statement that should mention the first-call contract more explicitly.
+5. Check `FEATURE_PARITY.md` for any stale feature-tracking wording.
+
+Expected result: the roadmap, RFC, user's guide, internal contract document,
+and architecture overview all describe the same first-call WASM contract.
+
+## Validation
+
+Run focused tests first and keep logs in `/tmp` as required by repository
+policy.
+
+```plaintext
+cargo test load_from_files_publishes_guest_schema_in_tool_definitions \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-loader.out
+
+cargo test remote_tool_catalog \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-remote-tools.out
+
+cargo test hosted_worker_proxy_definition_matches_orchestrator_canonical_definition \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-hosted-fidelity.out
+
+cargo test worker_ \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-worker.out
+```
+
+Add one targeted command for the new non-hosted trace-backed test once the test
+name is known.
+
+```plaintext
+cargo test <new_non_hosted_first_call_test_name> \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-first-call.out
+```
+
+If a focused hosted capture test lands with a stable name, run it directly as
+well.
+
+```plaintext
+cargo test <new_hosted_first_call_test_name> \
+  | tee /tmp/test-axinite-feat-plan-wasm-schema-e2e-hosted-first-call.out
+```
+
+Run the required full gate before commit.
+
+```plaintext
+make all \
+  | tee /tmp/make-all-axinite-feat-plan-wasm-schema-e2e.out
+```
+
+Run documentation hygiene checks for changed Markdown files.
+
+```plaintext
+bunx markdownlint-cli2 \
+  docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md \
+  docs/contents.md \
+  | tee /tmp/markdownlint-axinite-feat-plan-wasm-schema-e2e.out
+
+git diff --check \
+  | tee /tmp/diff-check-axinite-feat-plan-wasm-schema-e2e.out
+```
+
+If the implementation updates additional docs, add them to the Markdown lint
+command before the final commit.
+
+## Progress
+
+- [ ] 2026-04-14: Draft ExecPlan written and indexed in `docs/contents.md`.
+- [ ] Confirm non-hosted first-call capture seam and exact test location.
+- [ ] Confirm hosted first-call capture seam and exact test location.
+- [ ] Add non-hosted unit and behavioural regression coverage.
+- [ ] Add hosted first-call forwarding regression coverage.
+- [ ] Evaluate `rstest-bdd` proportionality and record the decision.
+- [ ] Synchronize roadmap, RFC, user-facing, and internal documentation.
+- [ ] Run validation gates, collect evidence, and commit.
+
+## Surprises & Discoveries
+
+- 2026-04-14: The user-requested file
+  `docs/axinite-architecture-summary.md` does not exist in this checkout. The
+  operative architecture reference is `docs/axinite-architecture-overview.md`.
+- 2026-04-14: The repository already has a trace-backed end-to-end rig that can
+  inspect captured LLM requests through `TestRig::captured_llm_requests()`,
+  which makes the non-hosted first-call proof much more direct than a pure
+  registry or reasoning-context assertion.
+- 2026-04-14: `docs/roadmap.md` marks `1.2.2` complete, but the corresponding
+  ExecPlan file still says `IN PROGRESS`. Treat adjacent documentation status
+  carefully when closing `1.2.4`.
+
+## Decision Log
+
+- 2026-04-14: Use `docs/axinite-architecture-overview.md` in place of the
+  missing `docs/axinite-architecture-summary.md`.
+  Rationale: it is the available maintainer-facing architecture reference in
+  this checkout and is already named as the fallback in adjacent WASM
+  ExecPlans.
+
+- 2026-04-14: Treat the non-hosted behavioural layer as a trace-backed
+  end-to-end request-capture test, not merely a reasoning-context assertion.
+  Rationale: RFC 0002 explicitly requires proof that the first request includes
+  the schema, and the trace rig can observe that request directly.
+
+- 2026-04-14: Prefer a narrow hosted request-capture seam around
+  `llm_complete_with_tools` instead of inventing a new hosted test framework.
+  Rationale: this keeps the existing worker-orchestrator transport as the only
+  contract boundary and follows the repository's dependency-injection testing
+  guidance.
+
+- 2026-04-14: `rstest-bdd` remains conditional rather than mandatory for this
+  slice.
+  Rationale: the repository already has strong `rstest` and trace-backed
+  harnesses, and a BDD scenario is only justified if it adds new observable
+  value without disproportionate scaffolding.
+
+## Outcomes & Retrospective
+
+Not yet implemented. Update this section after delivery with the final test
+matrix, documentation changes, validation evidence, and any lessons about
+capturing first-call tool contracts across in-process and hosted flows.

--- a/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
+++ b/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
@@ -268,7 +268,7 @@ request assembly.
    tool list with the advertised `parameters` schema before any tool execution
    occurs.
 3. Prefer the real GitHub WASM fixture and existing helper functions used by
-   the WASM loader tests so the behavioural proof is tied to the actual guest
+   the WASM loader tests, so the behavioural proof is tied to the actual guest
    metadata path rather than a native-tool stand-in.
 4. Add one unhappy-path assertion showing that a malformed first call still
    yields fallback guidance that points back to the already advertised schema.

--- a/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
+++ b/docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -417,14 +417,21 @@ command before the final commit.
 
 ## Progress
 
-- [ ] 2026-04-14: Draft ExecPlan written and indexed in `docs/contents.md`.
-- [ ] Confirm non-hosted first-call capture seam and exact test location.
-- [ ] Confirm hosted first-call capture seam and exact test location.
-- [ ] Add non-hosted unit and behavioural regression coverage.
-- [ ] Add hosted first-call forwarding regression coverage.
-- [ ] Evaluate `rstest-bdd` proportionality and record the decision.
-- [ ] Synchronize roadmap, RFC, user-facing, and internal documentation.
-- [ ] Run validation gates, collect evidence, and commit.
+- [x] 2026-04-14: Draft ExecPlan written and indexed in `docs/contents.md`.
+- [x] 2026-04-15T17:57:00+02:00: Confirm non-hosted first-call capture seam
+  and exact test location.
+- [x] 2026-04-15T17:57:00+02:00: Confirm hosted first-call capture seam and
+  exact test location.
+- [x] 2026-04-15T18:10:00+02:00: Add non-hosted unit and behavioural
+  regression coverage.
+- [x] 2026-04-15T18:10:00+02:00: Add hosted first-call forwarding regression
+  coverage.
+- [x] 2026-04-15T18:10:00+02:00: Evaluate `rstest-bdd` proportionality and
+  record the decision.
+- [x] 2026-04-15T18:15:00+02:00: Synchronize roadmap, RFC, user-facing, and
+  internal documentation.
+- [x] 2026-04-15T18:19:14+02:00: Run validation gates, collect evidence, and
+  prepare the commit.
 
 ## Surprises & Discoveries
 
@@ -438,6 +445,30 @@ command before the final commit.
 - 2026-04-14: `docs/roadmap.md` marks `1.2.2` complete, but the corresponding
   ExecPlan file still says `IN PROGRESS`. Treat adjacent documentation status
   carefully when closing `1.2.4`.
+- 2026-04-15T17:57:00+02:00: `TraceLlm` currently captures only
+  `ToolCompletionRequest.messages`, not the `tools` vector. A truthful
+  first-call assertion therefore requires either widening that capture or
+  using a narrow purpose-built capturing LLM in the behavioural test.
+- 2026-04-15T17:57:00+02:00: The hosted path already has an exact first-call
+  observation seam: `WorkerRuntime` uses `ProxyLlmProvider`, which forwards the
+  worker's first `ToolCompletionRequest` into
+  `WorkerHttpClient::llm_complete_with_tools()` and the shared
+  `ProxyToolCompletionRequest` transport type.
+- 2026-04-15T17:57:00+02:00: The repository currently has no `rstest-bdd`
+  scenarios under `src/` or `tests/`, so adding one here would introduce a new
+  feature-file and step-definition family rather than reusing an existing BDD
+  harness.
+- 2026-04-15T18:10:00+02:00: The smallest truthful non-hosted seam was a
+  purpose-built capturing LLM wired through `TestRigBuilder::with_llm(...)`.
+  That still exercises the real agent loop, real `Reasoning::respond_with_tools`
+  path, and real GitHub WASM registration helper while recording the first
+  `ToolCompletionRequest.tools` payload directly.
+- 2026-04-15T18:10:00+02:00: The smallest truthful hosted seam was an Axum
+  test server that served the remote-tool catalogue and captured the worker's
+  first proxied `POST /worker/{job_id}/llm/complete_with_tools` payload.
+- 2026-04-15T18:15:00+02:00: `FEATURE_PARITY.md` was reviewed during
+  documentation sync. No parity row described this WASM-schema contract
+  precisely enough to require an update.
 
 ## Decision Log
 
@@ -451,21 +482,76 @@ command before the final commit.
   end-to-end request-capture test, not merely a reasoning-context assertion.
   Rationale: RFC 0002 explicitly requires proof that the first request includes
   the schema, and the trace rig can observe that request directly.
+- 2026-04-15T17:57:00+02:00: Implement the non-hosted first-call proof with a
+  narrow capturing LLM provider wired through `TestRigBuilder::with_llm(...)`
+  while still exercising the real agent loop and real GitHub WASM registration
+  helper.
+  Rationale: this keeps the behavioural test end to end, avoids widening
+  shared trace support beyond what this slice needs, and records the actual
+  `ToolCompletionRequest.tools` payload that RFC 0002 cares about.
 
 - 2026-04-14: Prefer a narrow hosted request-capture seam around
   `llm_complete_with_tools` instead of inventing a new hosted test framework.
   Rationale: this keeps the existing worker-orchestrator transport as the only
   contract boundary and follows the repository's dependency-injection testing
   guidance.
+- 2026-04-15T17:57:00+02:00: Drive the hosted proof through
+  `Reasoning::respond_with_tools(...)` plus `WorkerRuntime`'s existing proxied
+  LLM field, backed by an Axum test server that captures the first
+  `ProxyToolCompletionRequest`.
+  Rationale: this observes the real first hosted request without introducing a
+  second transport seam or reaching directly into intermediate worker state.
 
 - 2026-04-14: `rstest-bdd` remains conditional rather than mandatory for this
   slice.
   Rationale: the repository already has strong `rstest` and trace-backed
   harnesses, and a BDD scenario is only justified if it adds new observable
   value without disproportionate scaffolding.
+- 2026-04-15T17:57:00+02:00: Do not add `rstest-bdd` coverage for this slice.
+  Rationale: there is no existing BDD harness to extend, the contract is more
+  directly observable through `rstest`-driven captured request payloads, and
+  adding feature files plus step definitions would exceed the proportionality
+  bar set in Milestone 5.
+- 2026-04-15T18:10:00+02:00: Keep the non-hosted first-call capture local to
+  the new behavioural test instead of widening shared trace-support APIs.
+  Rationale: only one roadmap item currently needs direct inspection of
+  `ToolCompletionRequest.tools`, and a local capturing provider preserved a
+  smaller blast radius than changing shared support used by many unrelated
+  trace tests.
 
 ## Outcomes & Retrospective
 
-Not yet implemented. Update this section after delivery with the final test
-matrix, documentation changes, validation evidence, and any lessons about
-capturing first-call tool contracts across in-process and hosted flows.
+Delivered the roadmap item with one new non-hosted end-to-end behavioural test,
+one new hosted first-call forwarding test, and one transport round-trip test
+for the shared proxied tool-completion request. The non-hosted proof uses the
+real agent loop plus the real GitHub WASM registration helper and records the
+first `ToolCompletionRequest.tools` payload before any tool executes. The
+hosted proof uses the real worker proxy LLM path and records the first
+`ProxyToolCompletionRequest` sent across the worker-orchestrator boundary.
+
+Validation evidence:
+
+- `cargo test first_llm_request_includes_advertised_schema_for_active_wasm_tool`
+  passed and wrote `/tmp/test-axinite-feat-plan-wasm-schema-e2e-first-call.out`.
+- `cargo test hosted_worker_first_llm_request_forwards_wasm_schema_on_first_call`
+  passed and wrote
+  `/tmp/test-axinite-feat-plan-wasm-schema-e2e-hosted-first-call.out`.
+- `cargo test worker_tool_completion_request_round_trips_through_shared_types`
+  passed and wrote
+  `/tmp/test-axinite-feat-plan-wasm-schema-e2e-transport-parity.out`.
+- `cargo test malformed_first_call_returns_fallback_guidance` passed and wrote
+  `/tmp/test-axinite-feat-plan-wasm-schema-e2e-fallback-guidance.out`.
+- `make all` passed and wrote
+  `/tmp/make-all-axinite-feat-plan-wasm-schema-e2e.out`.
+- `bunx markdownlint-cli2 ...` passed and wrote
+  `/tmp/markdownlint-axinite-feat-plan-wasm-schema-e2e.out`.
+- `git diff --check` passed and wrote
+  `/tmp/diff-check-axinite-feat-plan-wasm-schema-e2e.out`.
+
+Key lesson: the most reliable way to prove "first call already has the schema"
+is to capture the actual tool-capable request object at the LLM boundary, not
+to infer behaviour from registry state or reasoning-context assembly alone. In
+this repository that meant using two different narrow seams: a custom
+capturing provider for the in-process agent loop and an Axum capture stub for
+the hosted worker boundary. That kept the change proportional while still
+producing end-to-end evidence.

--- a/docs/rfcs/0002-expose-wasm-tool-definitions.md
+++ b/docs/rfcs/0002-expose-wasm-tool-definitions.md
@@ -5,16 +5,18 @@
 - **RFC number:** 0002
 - **Status:** Proposed
 - **Created:** 2026-03-11
-- **Implementation status:** Roadmap items `1.2.1`, `1.2.2`, and `1.2.3` are
-  complete.
+- **Implementation status:** Roadmap items `1.2.1`, `1.2.2`, `1.2.3`, and
+  `1.2.4` are complete.
   Active WASM registration paths now recover guest-exported metadata before
   publication, warn when registration falls back to a placeholder schema, and
   are covered by regression tests for file-loaded, storage-backed, and
   dev-build paths. Hosted workers now receive hosted-visible
   orchestrator-owned WASM definitions through the shared remote-tool catalogue.
   WASM execution failures now label retry hints as fallback diagnostics that
-  point back to the already advertised contract. Roadmap item `1.2.4` remains
-  open.
+  point back to the already advertised contract. End-to-end regression tests
+  now prove that the first non-hosted provider request and the first hosted
+  proxied `complete_with_tools` request both include the advertised WASM
+  schema before any tool execution attempt.
 
 ## Summary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,7 +132,7 @@ by tightening the contract around active WASM tools.
   - Success: wrapper comments and behaviour describe retry hints as supplemental
     help rather than the primary contract, while parse and validation failures
     still surface actionable recovery guidance.
-- [ ] 1.2.4. Add end-to-end tests for first-call WASM schema exposure. Requires
+- [x] 1.2.4. Add end-to-end tests for first-call WASM schema exposure. Requires
       1.2.2 and 1.2.3.
   - See [RFC 0002 §Goals](./rfcs/0002-expose-wasm-tool-definitions.md#goals) and
     [RFC 0002 §Migration Plan](./rfcs/0002-expose-wasm-tool-definitions.md#migration-plan).

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -21,7 +21,10 @@ execution still happens in the orchestrator process.
 If one of those hosted-visible WASM tools later fails, any retry guidance is
 supplemental recovery help only. The worker and orchestrator still treat the
 advertised `ToolDefinition.parameters` schema as the primary contract for the
-first call.
+first call. The same proactive first-call contract now applies in both the
+local in-process path and the hosted worker path: the first tool-capable model
+request already carries the advertised WASM schema before any execution
+attempt.
 
 The worker now computes one registry-backed tool surface for reasoning. That
 merged view is used both when the initial reasoning context is built and when

--- a/docs/worker-orchestrator-contract.md
+++ b/docs/worker-orchestrator-contract.md
@@ -166,5 +166,11 @@ payload is the canonical contract. Any later execution failure hint is a
 supplemental fallback diagnostic and must not become a second schema transport
 path across the worker boundary.
 
+That rule is observable at the first hosted LLM boundary. The worker's initial
+tool-capable request to `POST /worker/{job_id}/llm/complete_with_tools`
+forwards the same advertised WASM `ToolDefinition` values that came from the
+hosted catalogue, rather than relying on a failed first call to teach the
+schema.
+
 The shared route constants and transport types are what keep that hosted tool
 surface consistent across the sandbox boundary.

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -754,29 +754,24 @@ impl SignalChannel {
             // DM message - apply DM policy
             match self.config.dm_policy.as_str() {
                 "open" => {}
-                "pairing" => {
-                    // Pairing policy: check allow_from + pairing store
-                    if !self.is_sender_allowed_with_pairing(&sender) {
-                        // Handle pairing request - this will create a request and send reply if new
-                        match self.handle_pairing_request(&sender, envelope.source_name.as_deref())
-                        {
-                            Ok(_) => {
-                                // Pairing request processed (new or existing), drop the message
-                                return None;
-                            }
-                            Err(()) => {
-                                // Error processing pairing, drop message
-                                return None;
-                            }
+                // Pairing policy: check allow_from + pairing store
+                "pairing" if !self.is_sender_allowed_with_pairing(&sender) => {
+                    // Handle pairing request - this will create a request and send reply if new
+                    match self.handle_pairing_request(&sender, envelope.source_name.as_deref()) {
+                        Ok(_) => {
+                            // Pairing request processed (new or existing), drop the message
+                            return None;
+                        }
+                        Err(()) => {
+                            // Error processing pairing, drop message
+                            return None;
                         }
                     }
                 }
-                "allowlist" => {
-                    // Default: check allow_from list
-                    if !self.is_sender_allowed(&sender) {
-                        tracing::debug!(sender = %sender, "Signal: sender not in allow_from, dropping");
-                        return None;
-                    }
+                // Default: check allow_from list
+                "allowlist" if !self.is_sender_allowed(&sender) => {
+                    tracing::debug!(sender = %sender, "Signal: sender not in allow_from, dropping");
+                    return None;
                 }
                 _ => {}
             }

--- a/src/channels/web/handlers/chat_threads.rs
+++ b/src/channels/web/handlers/chat_threads.rs
@@ -85,7 +85,7 @@ pub async fn chat_threads_handler(
     }
 
     let mut sorted_threads: Vec<_> = sess.threads.values().collect();
-    sorted_threads.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    sorted_threads.sort_by_key(|b| std::cmp::Reverse(b.updated_at));
     let threads = sorted_threads
         .into_iter()
         .map(|thread| ThreadInfo {

--- a/src/cli/tool/auth.rs
+++ b/src/cli/tool/auth.rs
@@ -246,12 +246,10 @@ pub(super) fn read_hidden_input() -> anyhow::Result<String> {
         if let Event::Key(key_event) = event::read()? {
             match key_event.code {
                 KeyCode::Enter => break,
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        print!("\x08 \x08");
-                        std::io::stdout().flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    print!("\x08 \x08");
+                    std::io::stdout().flush()?;
                 }
                 KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                     return Err(anyhow::anyhow!("Interrupted"));

--- a/src/llm/rig_adapter/helpers.rs
+++ b/src/llm/rig_adapter/helpers.rs
@@ -51,10 +51,8 @@ pub(super) fn extract_response(
 
     for content in choice.iter() {
         match content {
-            AssistantContent::Text(t) => {
-                if !t.text.is_empty() {
-                    text_parts.push(t.text.clone());
-                }
+            AssistantContent::Text(t) if !t.text.is_empty() => {
+                text_parts.push(t.text.clone());
             }
             AssistantContent::ToolCall(tc) => {
                 tool_calls.push(IronToolCall {

--- a/src/orchestrator/api/tests/transport_parity.rs
+++ b/src/orchestrator/api/tests/transport_parity.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use super::super::remote_tools::hosted_remote_tool_catalog;
 use super::fixtures::remote_tool_mocks::complex_tool_stub;
+use crate::llm::ChatMessage;
 use crate::tools::ToolRegistry;
 
 #[tokio::test]
@@ -71,4 +72,43 @@ async fn orchestrator_execution_response_round_trips_through_worker_shared_types
         deserialized, execution_response,
         "execution response must round-trip without field loss"
     );
+}
+
+#[tokio::test]
+async fn worker_tool_completion_request_round_trips_through_shared_types() {
+    let registry = Arc::new(ToolRegistry::new());
+    registry.register(Arc::new(complex_tool_stub())).await;
+    let (tools, _instructions, _version) = hosted_remote_tool_catalog(&registry).await;
+
+    let completion_request = crate::worker::api::ProxyToolCompletionRequest {
+        messages: vec![
+            ChatMessage::system("Inspect the available tools."),
+            ChatMessage::user("What can you do with the remote WASM tool?"),
+        ],
+        tools,
+        model: Some("test-model".to_string()),
+        max_tokens: Some(512),
+        temperature: Some(0.1),
+        tool_choice: Some("auto".to_string()),
+    };
+
+    let serialized = serde_json::to_string(&completion_request)
+        .expect("serialize worker-built tool completion request");
+    let deserialized: crate::worker::api::ProxyToolCompletionRequest =
+        serde_json::from_str(&serialized)
+            .expect("worker tool request must deserialize into shared type");
+
+    assert_eq!(
+        deserialized.messages.len(),
+        completion_request.messages.len(),
+        "tool completion request must preserve message count"
+    );
+    assert_eq!(
+        deserialized.tools, completion_request.tools,
+        "tool completion request must preserve the full advertised tool definitions"
+    );
+    assert_eq!(deserialized.model, completion_request.model);
+    assert_eq!(deserialized.max_tokens, completion_request.max_tokens);
+    assert_eq!(deserialized.temperature, completion_request.temperature);
+    assert_eq!(deserialized.tool_choice, completion_request.tool_choice);
 }

--- a/src/orchestrator/api/tests/transport_parity.rs
+++ b/src/orchestrator/api/tests/transport_parity.rs
@@ -101,8 +101,22 @@ async fn worker_tool_completion_request_round_trips_through_shared_types() {
     assert_eq!(
         deserialized.messages.len(),
         completion_request.messages.len(),
-        "tool completion request must preserve message count"
+        "deserialized.messages must preserve the same number of entries as completion_request.messages"
     );
+    for (index, (deserialized_message, original_message)) in deserialized
+        .messages
+        .iter()
+        .zip(completion_request.messages.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            serde_json::to_value(deserialized_message)
+                .expect("serialize deserialized message for parity assertion"),
+            serde_json::to_value(original_message)
+                .expect("serialize original message for parity assertion"),
+            "deserialized.messages must preserve the full completion_request.messages payload at index {index}"
+        );
+    }
     assert_eq!(
         deserialized.tools, completion_request.tools,
         "tool completion request must preserve the full advertised tool definitions"

--- a/src/setup/prompts.rs
+++ b/src/setup/prompts.rs
@@ -133,10 +133,8 @@ pub fn select_many(prompt: &str, options: &[(&str, bool)]) -> io::Result<Vec<usi
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if cursor_pos < options.len() - 1 {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Down if cursor_pos < options.len() - 1 => {
+                        cursor_pos += 1;
                     }
                     KeyCode::Char(' ') => {
                         selected[cursor_pos] = !selected[cursor_pos];

--- a/src/setup/prompts.rs
+++ b/src/setup/prompts.rs
@@ -219,12 +219,10 @@ fn read_secret_line() -> io::Result<SecretString> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        execute!(stdout, Print("\x08 \x08"))?;
-                        stdout.flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    execute!(stdout, Print("\x08 \x08"))?;
+                    stdout.flush()?;
                 }
                 KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                     return Err(io::Error::new(io::ErrorKind::Interrupted, "Ctrl-C"));

--- a/src/skills/catalog.rs
+++ b/src/skills/catalog.rs
@@ -367,7 +367,7 @@ impl SkillCatalog {
 
         let details = futures::future::join_all(futures).await;
 
-        for (entry, detail) in entries[..count].iter_mut().zip(details.into_iter()) {
+        for (entry, detail) in entries[..count].iter_mut().zip(details) {
             if let Some(detail) = detail {
                 if let Some(ref stats) = detail.stats {
                     entry.stars = stats.stars;

--- a/src/worker/container/tests/hosted_fidelity.rs
+++ b/src/worker/container/tests/hosted_fidelity.rs
@@ -7,16 +7,21 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use axum::Json;
 use axum::extract::{Path, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
 use rstest::{fixture, rstest};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::llm::ToolDefinition;
-use crate::worker::api::{RemoteToolCatalogResponse, WorkerHttpClient};
+use crate::llm::{Reasoning, RespondResult, ToolDefinition};
+use crate::worker::api::ProxyFinishReason;
+use crate::worker::api::{
+    LLM_COMPLETE_WITH_TOOLS_ROUTE, ProxyToolCompletionRequest, ProxyToolCompletionResponse,
+    RemoteToolCatalogResponse, WorkerHttpClient,
+};
 use crate::worker::container::{WorkerConfig, WorkerRuntime};
-
-use super::remote_tools::{TestState, spawn_test_server};
 
 /// Test harness containing a [`WorkerRuntime`] configured with remote tools
 /// and the server join handle for shutdown.
@@ -25,6 +30,8 @@ pub struct HostedCatalogHarness {
     pub runtime: WorkerRuntime,
     /// Join handle for the background test server.
     pub server: tokio::task::JoinHandle<()>,
+    /// Captured proxied LLM tool-completion requests sent by the worker.
+    pub captured_requests: Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
 }
 
 fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
@@ -41,9 +48,10 @@ fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
 }
 
 async fn remote_tool_catalog_with_complex_tool(
-    State(_state): State<TestState>,
+    State(state): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
 ) -> Json<RemoteToolCatalogResponse> {
+    let _ = state;
     Json(RemoteToolCatalogResponse {
         tools: vec![complex_orchestrator_wasm_tool_definition()],
         toolset_instructions: vec![],
@@ -51,11 +59,65 @@ async fn remote_tool_catalog_with_complex_tool(
     })
 }
 
+#[derive(Clone, Default)]
+struct HostedCatalogTestState {
+    captured_requests: Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
+}
+
+async fn capture_llm_complete_with_tools(
+    State(state): State<HostedCatalogTestState>,
+    Path(_job_id): Path<Uuid>,
+    Json(request): Json<ProxyToolCompletionRequest>,
+) -> Json<ProxyToolCompletionResponse> {
+    state.captured_requests.lock().await.push(request);
+
+    Json(ProxyToolCompletionResponse {
+        content: Some("Hosted request captured.".to_string()),
+        tool_calls: Vec::new(),
+        input_tokens: 1,
+        output_tokens: 1,
+        finish_reason: ProxyFinishReason::Stop,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+    })
+}
+
+async fn spawn_hosted_catalog_server() -> Result<
+    (
+        String,
+        Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
+        tokio::task::JoinHandle<()>,
+    ),
+    anyhow::Error,
+> {
+    let state = HostedCatalogTestState::default();
+    let captured_requests = Arc::clone(&state.captured_requests);
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let router = Router::new()
+        .route(
+            crate::worker::api::REMOTE_TOOL_CATALOG_ROUTE,
+            get(remote_tool_catalog_with_complex_tool),
+        )
+        .route(
+            LLM_COMPLETE_WITH_TOOLS_ROUTE,
+            post(capture_llm_complete_with_tools),
+        )
+        .with_state(state);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("serve hosted fidelity test router")
+    });
+
+    Ok((format!("http://{addr}"), captured_requests, server))
+}
+
 /// Creates a [`HostedCatalogHarness`] with a test server serving the complex
 /// tool catalog.
 #[fixture]
 async fn hosted_catalog_harness() -> Result<HostedCatalogHarness, Box<dyn std::error::Error>> {
-    let (base_url, server) = spawn_test_server(remote_tool_catalog_with_complex_tool).await?;
+    let (base_url, captured_requests, server) = spawn_hosted_catalog_server().await?;
 
     let client = Arc::new(
         WorkerHttpClient::new(base_url.clone(), Uuid::nil(), "test".to_string())
@@ -71,7 +133,11 @@ async fn hosted_catalog_harness() -> Result<HostedCatalogHarness, Box<dyn std::e
     )
     .context("test runtime should build")?;
 
-    Ok(HostedCatalogHarness { runtime, server })
+    Ok(HostedCatalogHarness {
+        runtime,
+        server,
+        captured_requests,
+    })
 }
 
 #[rstest]
@@ -79,7 +145,9 @@ async fn hosted_catalog_harness() -> Result<HostedCatalogHarness, Box<dyn std::e
 async fn hosted_worker_proxy_definition_matches_orchestrator_canonical_definition(
     #[future] hosted_catalog_harness: Result<HostedCatalogHarness, Box<dyn std::error::Error>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let HostedCatalogHarness { runtime, server } = hosted_catalog_harness.await?;
+    let HostedCatalogHarness {
+        runtime, server, ..
+    } = hosted_catalog_harness.await?;
 
     runtime.register_remote_tools().await?;
 
@@ -102,6 +170,61 @@ async fn hosted_worker_proxy_definition_matches_orchestrator_canonical_definitio
         "worker-advertised proxy definition must match orchestrator canonical definition exactly"
     );
 
+    server.abort();
+    let _ = server.await;
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn hosted_worker_first_llm_request_forwards_wasm_schema_on_first_call(
+    #[future] hosted_catalog_harness: Result<HostedCatalogHarness, Box<dyn std::error::Error>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let HostedCatalogHarness {
+        runtime,
+        server,
+        captured_requests,
+    } = hosted_catalog_harness.await?;
+
+    runtime.register_remote_tools().await?;
+
+    let reason_ctx = runtime
+        .build_reasoning_context(&crate::worker::api::JobDescription {
+            title: "Capture first hosted request".to_string(),
+            description: "Inspect the first proxied tool-capable LLM request.".to_string(),
+            project_dir: None,
+        })
+        .await;
+    let reasoning = Reasoning::new(Arc::clone(&runtime.llm));
+    let output = reasoning.respond_with_tools(&reason_ctx).await?;
+
+    match output.result {
+        RespondResult::Text(text) => {
+            assert!(
+                text.contains("Hosted request captured"),
+                "expected the proxied hosted stub response, got: {text}"
+            );
+        }
+        other => panic!("expected a text response from the hosted capture stub, got {other:?}"),
+    }
+
+    let captured_requests = captured_requests.lock().await;
+    let first_request = captured_requests
+        .first()
+        .expect("expected one proxied tool-completion request");
+    let forwarded_wasm_tool = first_request
+        .tools
+        .iter()
+        .find(|tool| tool.name == "complex_orchestrator_wasm_fidelity_fixture")
+        .expect("worker should forward the orchestrator-owned WASM tool on the first request");
+
+    assert_eq!(
+        forwarded_wasm_tool,
+        &complex_orchestrator_wasm_tool_definition(),
+        "the first proxied request must preserve the orchestrator-owned WASM schema exactly"
+    );
+
+    drop(captured_requests);
     server.abort();
     let _ = server.await;
     Ok(())

--- a/src/worker/container/tests/hosted_fidelity.rs
+++ b/src/worker/container/tests/hosted_fidelity.rs
@@ -34,6 +34,8 @@ pub struct HostedCatalogHarness {
     pub captured_requests: Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
 }
 
+/// Builds the canonical orchestrator-owned WASM tool definition used by
+/// fidelity and first-call assertion tests.
 fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
     crate::test_support::build_complex_tool_definition(
         "complex_orchestrator_wasm_fidelity_fixture",
@@ -47,6 +49,8 @@ fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
     )
 }
 
+/// Axum handler that returns a catalog containing [`complex_orchestrator_wasm_tool_definition`]
+/// for the remote-tool catalog route.
 async fn remote_tool_catalog_with_complex_tool(
     State(_): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
@@ -58,11 +62,15 @@ async fn remote_tool_catalog_with_complex_tool(
     })
 }
 
+/// Shared state for the hosted-catalog test server, holding the buffer of
+/// captured proxied LLM tool-completion requests.
 #[derive(Clone, Default)]
 struct HostedCatalogTestState {
     captured_requests: Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
 }
 
+/// Axum handler that records each incoming [`ProxyToolCompletionRequest`]
+/// and returns a deterministic stub completion response.
 async fn capture_llm_complete_with_tools(
     State(state): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
@@ -81,6 +89,11 @@ async fn capture_llm_complete_with_tools(
     })
 }
 
+/// Spawns a local Axum server that serves the complex tool catalog and
+/// captures proxied LLM tool-completion requests.
+///
+/// Returns the base URL, a handle to the captured-requests buffer, and the
+/// server join handle.
 async fn spawn_hosted_catalog_server() -> Result<
     (
         String,
@@ -112,8 +125,8 @@ async fn spawn_hosted_catalog_server() -> Result<
     Ok((format!("http://{addr}"), captured_requests, server))
 }
 
-/// Creates a [`HostedCatalogHarness`] with a test server serving the complex
-/// tool catalog.
+/// rstest fixture that starts a [`spawn_hosted_catalog_server`] instance and
+/// builds a [`HostedCatalogHarness`] wired to it.
 #[fixture]
 async fn hosted_catalog_harness() -> Result<HostedCatalogHarness, Box<dyn std::error::Error>> {
     let (base_url, captured_requests, server) = spawn_hosted_catalog_server().await?;

--- a/src/worker/container/tests/hosted_fidelity.rs
+++ b/src/worker/container/tests/hosted_fidelity.rs
@@ -48,10 +48,9 @@ fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
 }
 
 async fn remote_tool_catalog_with_complex_tool(
-    State(state): State<HostedCatalogTestState>,
+    State(_): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
 ) -> Json<RemoteToolCatalogResponse> {
-    let _ = state;
     Json(RemoteToolCatalogResponse {
         tools: vec![complex_orchestrator_wasm_tool_definition()],
         toolset_instructions: vec![],

--- a/src/worker/container/tests/hosted_fidelity.rs
+++ b/src/worker/container/tests/hosted_fidelity.rs
@@ -35,7 +35,7 @@ pub struct HostedCatalogHarness {
 }
 
 /// Builds the canonical orchestrator-owned WASM tool definition used by
-/// fidelity and first-call assertion tests.
+/// fidelity and first-call schema assertion tests.
 fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
     crate::test_support::build_complex_tool_definition(
         "complex_orchestrator_wasm_fidelity_fixture",
@@ -49,8 +49,9 @@ fn complex_orchestrator_wasm_tool_definition() -> ToolDefinition {
     )
 }
 
-/// Axum handler that returns a catalog containing [`complex_orchestrator_wasm_tool_definition`]
-/// for the remote-tool catalog route.
+/// Axum handler that returns a catalogue containing
+/// [`complex_orchestrator_wasm_tool_definition`] for the remote-tool
+/// catalogue route.
 async fn remote_tool_catalog_with_complex_tool(
     State(_): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
@@ -62,15 +63,15 @@ async fn remote_tool_catalog_with_complex_tool(
     })
 }
 
-/// Shared state for the hosted-catalog test server, holding the buffer of
-/// captured proxied LLM tool-completion requests.
+/// Shared Axum state holding the buffer of captured proxied LLM
+/// tool-completion requests.
 #[derive(Clone, Default)]
 struct HostedCatalogTestState {
     captured_requests: Arc<Mutex<Vec<ProxyToolCompletionRequest>>>,
 }
 
 /// Axum handler that records each incoming [`ProxyToolCompletionRequest`]
-/// and returns a deterministic stub completion response.
+/// into shared state and returns a deterministic stub completion response.
 async fn capture_llm_complete_with_tools(
     State(state): State<HostedCatalogTestState>,
     Path(_job_id): Path<Uuid>,
@@ -89,7 +90,7 @@ async fn capture_llm_complete_with_tools(
     })
 }
 
-/// Spawns a local Axum server that serves the complex tool catalog and
+/// Spawns a local Axum server that serves the complex tool catalogue and
 /// captures proxied LLM tool-completion requests.
 ///
 /// Returns the base URL, a handle to the captured-requests buffer, and the
@@ -125,8 +126,8 @@ async fn spawn_hosted_catalog_server() -> Result<
     Ok((format!("http://{addr}"), captured_requests, server))
 }
 
-/// rstest fixture that starts a [`spawn_hosted_catalog_server`] instance and
-/// builds a [`HostedCatalogHarness`] wired to it.
+/// rstest fixture that starts a [`spawn_hosted_catalog_server`] instance
+/// and builds a [`HostedCatalogHarness`] wired to it.
 #[fixture]
 async fn hosted_catalog_harness() -> Result<HostedCatalogHarness, Box<dyn std::error::Error>> {
     let (base_url, captured_requests, server) = spawn_hosted_catalog_server().await?;

--- a/tests/e2e_traces.rs
+++ b/tests/e2e_traces.rs
@@ -39,6 +39,7 @@ mod trace_error_path;
 mod trace_file_tools;
 #[path = "e2e_traces/trace_memory.rs"]
 mod trace_memory;
+#[cfg(feature = "test-helpers")]
 #[path = "e2e_traces/wasm_schema_exposure.rs"]
 mod wasm_schema_exposure;
 #[path = "e2e_traces/worker_coverage.rs"]

--- a/tests/e2e_traces.rs
+++ b/tests/e2e_traces.rs
@@ -39,6 +39,8 @@ mod trace_error_path;
 mod trace_file_tools;
 #[path = "e2e_traces/trace_memory.rs"]
 mod trace_memory;
+#[path = "e2e_traces/wasm_schema_exposure.rs"]
+mod wasm_schema_exposure;
 #[path = "e2e_traces/worker_coverage.rs"]
 mod worker_coverage;
 #[path = "e2e_traces/workspace_coverage.rs"]

--- a/tests/e2e_traces/wasm_schema_exposure.rs
+++ b/tests/e2e_traces/wasm_schema_exposure.rs
@@ -1,0 +1,160 @@
+//! End-to-end coverage for proactive WASM schema advertisement on the first
+//! LLM request.
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use rstest::{fixture, rstest};
+use rust_decimal::Decimal;
+
+use crate::support::fixtures::DEFAULT_TIMEOUT;
+use crate::support::test_rig::TestRigBuilder;
+
+use ironclaw::error::LlmError;
+use ironclaw::llm::{
+    CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCompletionRequest,
+    ToolCompletionResponse, ToolDefinition,
+};
+use ironclaw::testing::github_wasm_wrapper;
+use ironclaw::tools::Tool;
+
+#[derive(Clone)]
+struct GithubWasmFixture {
+    tool: Arc<dyn Tool>,
+    definition: ToolDefinition,
+}
+
+#[derive(Default)]
+struct CapturingToolLlm {
+    requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
+}
+
+impl CapturingToolLlm {
+    async fn captured_requests(&self) -> Vec<ToolCompletionRequest> {
+        self.requests.lock().await.clone()
+    }
+}
+
+impl ironclaw::llm::NativeLlmProvider for CapturingToolLlm {
+    fn model_name(&self) -> &str {
+        "capturing-tool-llm"
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        (Decimal::ZERO, Decimal::ZERO)
+    }
+
+    async fn complete(&self, _request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        Ok(CompletionResponse {
+            content: "text fallback".to_string(),
+            input_tokens: 1,
+            output_tokens: 1,
+            finish_reason: FinishReason::Stop,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        })
+    }
+
+    async fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.requests.lock().await.push(request);
+        Ok(ToolCompletionResponse {
+            content: Some("No tool use needed.".to_string()),
+            tool_calls: Vec::new(),
+            input_tokens: 1,
+            output_tokens: 1,
+            finish_reason: FinishReason::Stop,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        })
+    }
+}
+
+#[fixture]
+async fn github_wasm_fixture() -> anyhow::Result<GithubWasmFixture> {
+    let wrapper = github_wasm_wrapper()
+        .await
+        .context("build shared github WASM wrapper")?;
+    let definition = ToolDefinition {
+        name: wrapper.name().to_string(),
+        description: wrapper.description().to_string(),
+        parameters: wrapper.parameters_schema(),
+    };
+
+    Ok(GithubWasmFixture {
+        tool: Arc::new(wrapper),
+        definition,
+    })
+}
+
+#[fixture]
+fn capturing_llm() -> Arc<CapturingToolLlm> {
+    Arc::new(CapturingToolLlm::default())
+}
+
+#[rstest]
+#[tokio::test]
+async fn first_llm_request_includes_advertised_schema_for_active_wasm_tool(
+    #[future] github_wasm_fixture: anyhow::Result<GithubWasmFixture>,
+    capturing_llm: Arc<CapturingToolLlm>,
+) -> anyhow::Result<()> {
+    let github_wasm_fixture = github_wasm_fixture.await?;
+    let llm: Arc<dyn LlmProvider> = capturing_llm.clone();
+    let rig = TestRigBuilder::new()
+        .with_llm(llm)
+        .with_extra_tools(vec![Arc::clone(&github_wasm_fixture.tool)])
+        .build()
+        .await
+        .context("build end-to-end rig with real github WASM tool")?;
+
+    rig.send_message("Review the available tool surface before taking any action.")
+        .await;
+    let responses = rig.wait_for_responses(1, DEFAULT_TIMEOUT).await;
+    assert_eq!(responses.len(), 1, "expected a single assistant response");
+    assert!(
+        rig.tool_calls_started().is_empty(),
+        "capturing LLM should not have triggered tool execution before assertion"
+    );
+
+    let captured_requests = capturing_llm.captured_requests().await;
+    let first_request = captured_requests
+        .first()
+        .expect("expected one captured tool-capable LLM request");
+    let github = first_request
+        .tools
+        .iter()
+        .find(|tool| tool.name == github_wasm_fixture.definition.name)
+        .expect("first request should advertise the active github WASM tool");
+
+    assert_eq!(
+        github, &github_wasm_fixture.definition,
+        "the first LLM request must carry the same WASM schema advertised at registration time"
+    );
+    assert_eq!(github.parameters["type"], serde_json::json!("object"));
+    assert!(
+        github.parameters["required"]
+            .as_array()
+            .expect("github schema should expose required fields")
+            .iter()
+            .any(|value| value == "action"),
+        "github schema should keep the required action field on the first request"
+    );
+    assert!(
+        github.parameters["properties"]["owner"].is_object(),
+        "github schema should keep real guest-defined properties on the first request"
+    );
+    assert_ne!(
+        github.parameters,
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+        }),
+        "first request must not fall back to the placeholder WASM schema"
+    );
+
+    rig.shutdown();
+    Ok(())
+}

--- a/tests/e2e_traces/wasm_schema_exposure.rs
+++ b/tests/e2e_traces/wasm_schema_exposure.rs
@@ -18,18 +18,23 @@ use ironclaw::llm::{
 use ironclaw::testing::github_wasm_wrapper;
 use ironclaw::tools::Tool;
 
+/// A pre-built GitHub WASM tool and its registration-time [`ToolDefinition`],
+/// shared across schema-exposure assertions.
 #[derive(Clone)]
 struct GithubWasmFixture {
     tool: Arc<dyn Tool>,
     definition: ToolDefinition,
 }
 
+/// A test-only [`NativeLlmProvider`] that records every [`ToolCompletionRequest`]
+/// it receives and returns a deterministic no-op response.
 #[derive(Default)]
 struct CapturingToolLlm {
     requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
 }
 
 impl CapturingToolLlm {
+    /// Returns a snapshot of all [`ToolCompletionRequest`]s recorded so far.
     async fn captured_requests(&self) -> Vec<ToolCompletionRequest> {
         self.requests.lock().await.clone()
     }
@@ -72,6 +77,8 @@ impl ironclaw::llm::NativeLlmProvider for CapturingToolLlm {
     }
 }
 
+/// rstest fixture that builds and returns a [`GithubWasmFixture`] backed by
+/// the shared GitHub WASM test artifact.
 #[fixture]
 async fn github_wasm_fixture() -> anyhow::Result<GithubWasmFixture> {
     let wrapper = github_wasm_wrapper()
@@ -89,6 +96,8 @@ async fn github_wasm_fixture() -> anyhow::Result<GithubWasmFixture> {
     })
 }
 
+/// rstest fixture that returns a fresh [`CapturingToolLlm`] wrapped in an
+/// [`Arc`].
 #[fixture]
 fn capturing_llm() -> Arc<CapturingToolLlm> {
     Arc::new(CapturingToolLlm::default())

--- a/tests/e2e_traces/wasm_schema_exposure.rs
+++ b/tests/e2e_traces/wasm_schema_exposure.rs
@@ -12,22 +12,23 @@ use crate::support::test_rig::TestRigBuilder;
 
 use ironclaw::error::LlmError;
 use ironclaw::llm::{
-    CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCompletionRequest,
-    ToolCompletionResponse, ToolDefinition,
+    CompletionRequest, CompletionResponse, FinishReason, LlmProvider, NativeLlmProvider,
+    ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
 };
 use ironclaw::testing::github_wasm_wrapper;
 use ironclaw::tools::Tool;
 
-/// A pre-built GitHub WASM tool and its registration-time [`ToolDefinition`],
-/// shared across schema-exposure assertions.
+/// A pre-built GitHub WASM tool and its registration-time
+/// [`ToolDefinition`], shared across schema-exposure assertions.
 #[derive(Clone)]
 struct GithubWasmFixture {
     tool: Arc<dyn Tool>,
     definition: ToolDefinition,
 }
 
-/// A test-only [`NativeLlmProvider`] that records every [`ToolCompletionRequest`]
-/// it receives and returns a deterministic no-op response.
+/// A test-only [`NativeLlmProvider`] that records every
+/// [`ToolCompletionRequest`] it receives and returns a deterministic
+/// no-op response.
 #[derive(Default)]
 struct CapturingToolLlm {
     requests: tokio::sync::Mutex<Vec<ToolCompletionRequest>>,
@@ -40,7 +41,7 @@ impl CapturingToolLlm {
     }
 }
 
-impl ironclaw::llm::NativeLlmProvider for CapturingToolLlm {
+impl NativeLlmProvider for CapturingToolLlm {
     fn model_name(&self) -> &str {
         "capturing-tool-llm"
     }
@@ -77,8 +78,8 @@ impl ironclaw::llm::NativeLlmProvider for CapturingToolLlm {
     }
 }
 
-/// rstest fixture that builds and returns a [`GithubWasmFixture`] backed by
-/// the shared GitHub WASM test artifact.
+/// rstest fixture that builds and returns a [`GithubWasmFixture`] backed
+/// by the shared GitHub WASM test artifact.
 #[fixture]
 async fn github_wasm_fixture() -> anyhow::Result<GithubWasmFixture> {
     let wrapper = github_wasm_wrapper()
@@ -96,8 +97,8 @@ async fn github_wasm_fixture() -> anyhow::Result<GithubWasmFixture> {
     })
 }
 
-/// rstest fixture that returns a fresh [`CapturingToolLlm`] wrapped in an
-/// [`Arc`].
+/// rstest fixture that returns a fresh [`CapturingToolLlm`] wrapped in
+/// an [`Arc`].
 #[fixture]
 fn capturing_llm() -> Arc<CapturingToolLlm> {
     Arc::new(CapturingToolLlm::default())

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -15,10 +15,8 @@ pub use ironclaw::llm::recording::{
 /// Recursively patch string values in a JSON value, replacing `from` with `to`.
 pub(super) fn patch_json_value(value: &mut serde_json::Value, from: &str, to: &str) {
     match value {
-        serde_json::Value::String(s) => {
-            if s.contains(from) {
-                *s = s.replace(from, to);
-            }
+        serde_json::Value::String(s) if s.contains(from) => {
+            *s = s.replace(from, to);
         }
         serde_json::Value::Array(arr) => {
             for item in arr {


### PR DESCRIPTION
## Summary
- add non-hosted and hosted regression tests proving active WASM tools expose their advertised schema on the first tool-capable LLM request
- add a shared transport round-trip test for proxied tool completion payloads so hosted forwarding cannot silently drop WASM definitions
- update the ExecPlan, roadmap, RFC, user guide, worker contract, and architecture overview to document the enforced first-call contract

## Why
RFC 0002 requires proactive WASM schema publication to be the normal contract. This change closes roadmap item 1.2.4 by making regressions fail in both local and hosted paths instead of relying on a failed first call to discover the schema.

## Validation
- cargo test first_llm_request_includes_advertised_schema_for_active_wasm_tool --test e2e_traces
- cargo test hosted_worker_first_llm_request_forwards_wasm_schema_on_first_call
- cargo test worker_tool_completion_request_round_trips_through_shared_types
- cargo test malformed_first_call_returns_fallback_guidance
- make all
- bunx markdownlint-cli2 docs/execplans/1-2-4-end-to-end-tests-for-first-call-wasm-schema-exposure.md docs/roadmap.md docs/rfcs/0002-expose-wasm-tool-definitions.md docs/users-guide.md docs/worker-orchestrator-contract.md docs/axinite-architecture-overview.md
- git diff --check

## Summary by Sourcery

Add regression coverage to ensure WASM tool schemas are proactively exposed on the first tool-capable LLM request in both local and hosted flows, and document the completed first-call contract.

New Features:
- Introduce an end-to-end test harness that uses a capturing LLM to verify the first non-hosted tool-capable request includes the advertised WASM schema for an active GitHub WASM tool.
- Add a hosted worker test harness that captures proxied tool-completion requests to confirm orchestrator-owned WASM tool schemas are forwarded on the first hosted `complete_with_tools` call.

Enhancements:
- Extend hosted fidelity tests with a custom Axum test server and shared state to capture and inspect worker `ProxyToolCompletionRequest` payloads.
- Add a transport parity test to ensure `ProxyToolCompletionRequest` round-trips losslessly through shared worker/orchestrator types, preserving tool definitions and request options.

Documentation:
- Mark roadmap item 1.2.4 as complete and update RFC 0002 to reflect end-to-end first-call WASM schema coverage.
- Clarify architecture overview, worker-orchestrator contract, and user guide to describe the proactive first-call WASM schema contract for both local and hosted paths.
- Add a new ExecPlan documenting the approach, constraints, risks, and outcomes for end-to-end tests validating first-call WASM schema exposure, and index it in the docs contents.

Tests:
- Add an end-to-end trace test that asserts the first LLM tool-capable request includes the real GitHub WASM tool schema and not the placeholder schema.
- Add a hosted worker test that verifies the first proxied `complete_with_tools` request preserves the orchestrator-owned WASM tool definition exactly.
- Introduce a transport round-trip test for `ProxyToolCompletionRequest` to guard against schema loss across the worker-orchestrator boundary.