### PR TITLE
Refactor trace fixture mutation with serde_json

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -535,6 +535,85 @@ fans test slices out from that artifact. That is the closest existing
 example of the faster compile-once, fan-out pattern the compile-time
 reduction effort should reuse elsewhere.
 
+## Trace and channel test helpers
+
+Three test-support helpers were added in PR `#161` to make replay-based
+and worker-coverage tests more reliable.
+
+### `load_trace_with_mutation`
+
+Declared in `tests/support/trace_types.rs`, re-exported from
+`tests/support/trace_llm.rs`.
+
+Signature:
+
+```rust
+pub async fn load_trace_with_mutation<F>(
+    path: impl AsRef<Path>,
+    mutate: F,
+) -> anyhow::Result<LlmTrace>
+where
+    F: FnOnce(&mut serde_json::Value),
+```
+
+Reads a JSON trace fixture, deserialises it into a `serde_json::Value`,
+applies the caller-supplied `mutate` closure, then re-deserialises the
+result into `LlmTrace`. Use this instead of `LlmTrace::from_file_async`
+whenever a fixture field must be patched at test time, for example,
+rewriting a hard-coded temp path to the actual test directory:
+
+```rust
+let trace = load_trace_with_mutation("fixtures/trace.json", |v| {
+    v["steps"][0]["tool_calls"][0]["arguments"]["path"] =
+        serde_json::json!(test_dir.path().to_str().unwrap());
+})
+.await?;
+```
+
+### `tool_calls_completed_async`
+
+Declared on `TestChannel` and forwarded by `TestRig`
+(`tests/support/test_rig/rig.rs`).
+
+Signature:
+
+```rust
+pub async fn tool_calls_completed_async(&self) -> Vec<(String, bool)>
+```
+
+Returns the same data as the synchronous `tool_calls_completed` but
+acquires the status-event mutex with `.await` instead of `try_lock`.
+Use the async variant inside polling loops where status events may still
+be arriving when the assertion runs:
+
+```rust
+let completed = tokio::time::timeout(Duration::from_secs(5), async {
+    loop {
+        let c = rig.tool_calls_completed_async().await;
+        if c.iter().any(|(n, ok)| n == "write_file" && *ok) {
+            break c;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+})
+.await
+.expect("timed out waiting for write_file completion");
+```
+
+### `captured_status_events_async`
+
+Declared on `TestChannel` and forwarded by `TestRig`.
+
+Signature:
+
+```rust
+pub async fn captured_status_events_async(&self) -> Vec<StatusUpdate>
+```
+
+Returns a snapshot of all captured `StatusUpdate` values using an
+awaited mutex lock. Use this when contention on the status-event lock
+would cause `captured_status_events` to panic.
+
 ## WASM-specific notes
 
 The repository contains standalone WASM tool and channel crates. Normal
@@ -1048,4 +1127,3 @@ project's four-argument limit:
 | `hydration.rs` | Lazy thread hydration from the backing store when a known external thread ID is first referenced |
 | `persistence.rs` | Durable write helpers for user messages, assistant responses, and tool-call summaries |
 | `approval.rs` | Resume-from-approval flow after user consent is received |
-

--- a/tests/e2e_traces/advanced_traces.rs
+++ b/tests/e2e_traces/advanced_traces.rs
@@ -119,6 +119,22 @@ async fn tool_error_recovery() {
         "expected 2 write_file calls (bad + good), got {write_count}"
     );
 
+    // Wait for the successful recovery write to be recorded before reading.
+    let completed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let completed = rig.tool_calls_completed();
+            if completed
+                .iter()
+                .any(|(name, success)| name == "write_file" && *success)
+            {
+                break completed;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for successful recovery write");
+
     // The second write should have succeeded on disk.
     let content = tokio::fs::read_to_string("/tmp/ironclaw_recovery_test.txt")
         .await
@@ -126,7 +142,6 @@ async fn tool_error_recovery() {
     assert_eq!(content, "recovered successfully");
 
     // At least one write should have completed with success=true.
-    let completed = rig.tool_calls_completed();
     let any_success = completed
         .iter()
         .any(|(name, success)| name == "write_file" && *success);

--- a/tests/e2e_traces/advanced_traces.rs
+++ b/tests/e2e_traces/advanced_traces.rs
@@ -122,7 +122,7 @@ async fn tool_error_recovery() {
     // Wait for the successful recovery write to be recorded before reading.
     let completed = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            let completed = rig.tool_calls_completed();
+            let completed = rig.tool_calls_completed_async().await;
             if completed
                 .iter()
                 .any(|(name, success)| name == "write_file" && *success)

--- a/tests/e2e_traces/worker_coverage.rs
+++ b/tests/e2e_traces/worker_coverage.rs
@@ -14,7 +14,7 @@ use ironclaw::context::JobContext;
 use ironclaw::tools::{NativeTool, Tool, ToolError, ToolOutput};
 
 use crate::support::test_rig::{TestRig, TestRigBuilder};
-use crate::support::trace_llm::LlmTrace;
+use crate::support::trace_llm::{LlmTrace, load_trace_with_mutation};
 
 // -- Stub tools for rate-limit and timeout tests --------------------------
 
@@ -146,20 +146,23 @@ async fn tool_error_feedback() {
     let test_dir = tmp.path().to_str().expect("tempdir path");
 
     // Load and patch the fixture's recovery path to use our tempdir.
-    let mut trace = LlmTrace::from_file_async(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/llm_traces/worker/tool_error_feedback.json"
-    ))
+    let trace = load_trace_with_mutation(
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/llm_traces/worker/tool_error_feedback.json"
+        ),
+        |value| {
+            let recovery_path =
+                &mut value["steps"][1]["response"]["tool_calls"][0]["arguments"]["path"];
+            assert!(
+                recovery_path.is_string(),
+                "expected worker/tool_error_feedback.json recovery path to be a string"
+            );
+            *recovery_path = serde_json::Value::String(format!("{test_dir}/recovered.txt"));
+        },
+    )
     .await
     .expect("failed to load worker/tool_error_feedback.json");
-    let patch_count = trace.patch_path(
-        "/tmp/ironclaw_error_feedback_test/recovered.txt",
-        &format!("{test_dir}/recovered.txt"),
-    );
-    assert!(
-        patch_count > 0,
-        "expected to patch recovery path in worker/tool_error_feedback.json"
-    );
 
     let rig = TestRigBuilder::new()
         .with_trace(trace.clone())

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -50,6 +50,11 @@ type AsyncOutgoingResponses<'a> = std::pin::Pin<
 >;
 type AsyncTraceMetrics<'a> =
     std::pin::Pin<Box<dyn std::future::Future<Output = metrics::TraceMetrics> + 'a>>;
+type AsyncCompletedToolCalls<'a> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Vec<(String, bool)>> + 'a>>;
+type AsyncStatusEvents<'a> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Vec<ironclaw::channels::StatusUpdate>> + 'a>,
+>;
 type AsyncTraceRun<'a> = std::pin::Pin<
     Box<dyn std::future::Future<Output = Vec<Vec<ironclaw::channels::OutgoingResponse>>> + 'a>,
 >;
@@ -188,6 +193,16 @@ fn _collect_metrics_sig<'a>(rig: &'a test_rig::TestRig) -> AsyncTraceMetrics<'a>
 }
 
 #[cfg(feature = "libsql")]
+fn _tool_calls_completed_async_sig<'a>(rig: &'a test_rig::TestRig) -> AsyncCompletedToolCalls<'a> {
+    Box::pin(test_rig::TestRig::tool_calls_completed_async(rig))
+}
+
+#[cfg(feature = "libsql")]
+fn _captured_status_events_async_sig<'a>(rig: &'a test_rig::TestRig) -> AsyncStatusEvents<'a> {
+    Box::pin(test_rig::TestRig::captured_status_events_async(rig))
+}
+
+#[cfg(feature = "libsql")]
 fn _run_trace_sig<'a>(
     rig: &'a test_rig::TestRig,
     trace: &'a trace_llm::LlmTrace,
@@ -311,6 +326,14 @@ fn touch_test_rig_async_sigs() {
     );
     touch_const!(for<'a> fn(&'a test_rig::TestRig) -> AsyncUnit<'a> = _clear_sig);
     touch_const!(for<'a> fn(&'a test_rig::TestRig) -> AsyncTraceMetrics<'a> = _collect_metrics_sig);
+    touch_const!(
+        for<'a> fn(&'a test_rig::TestRig) -> AsyncCompletedToolCalls<'a> =
+            _tool_calls_completed_async_sig
+    );
+    touch_const!(
+        for<'a> fn(&'a test_rig::TestRig) -> AsyncStatusEvents<'a> =
+            _captured_status_events_async_sig
+    );
     touch_const!(
         for<'a> fn(
             &'a test_rig::TestRig,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -152,6 +152,7 @@ fn trace_support_symbol_refs() {
     assert_trace_llm_from_file_async(trace_llm::TraceLlm::from_file_async);
     let _: fn(String) -> _ = trace_llm::LlmTrace::from_file_async;
     assert_trace_from_file_async(trace_llm::LlmTrace::from_file_async);
+    let _: fn(String, fn(&mut serde_json::Value)) -> _ = trace_llm::load_trace_with_mutation;
 }
 
 #[cfg(feature = "libsql")]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -311,7 +311,7 @@ fn touch_test_rig_observers() {
 }
 
 #[cfg(feature = "libsql")]
-fn touch_test_rig_async_sigs() {
+fn touch_test_rig_async_message_sigs() {
     touch_const!(for<'a> fn(&'a test_rig::TestRig, &'a str) -> AsyncUnit<'a> = _send_message_sig);
     touch_const!(
         for<'a> fn(&'a test_rig::TestRig, ironclaw::channels::IncomingMessage) -> AsyncUnit<'a> =
@@ -325,6 +325,10 @@ fn touch_test_rig_async_sigs() {
         ) -> AsyncOutgoingResponses<'a> = _wait_for_responses_sig
     );
     touch_const!(for<'a> fn(&'a test_rig::TestRig) -> AsyncUnit<'a> = _clear_sig);
+}
+
+#[cfg(feature = "libsql")]
+fn touch_test_rig_async_observation_sigs() {
     touch_const!(for<'a> fn(&'a test_rig::TestRig) -> AsyncTraceMetrics<'a> = _collect_metrics_sig);
     touch_const!(
         for<'a> fn(&'a test_rig::TestRig) -> AsyncCompletedToolCalls<'a> =
@@ -334,6 +338,10 @@ fn touch_test_rig_async_sigs() {
         for<'a> fn(&'a test_rig::TestRig) -> AsyncStatusEvents<'a> =
             _captured_status_events_async_sig
     );
+}
+
+#[cfg(feature = "libsql")]
+fn touch_test_rig_async_trace_sigs() {
     touch_const!(
         for<'a> fn(
             &'a test_rig::TestRig,
@@ -348,6 +356,13 @@ fn touch_test_rig_async_sigs() {
             std::time::Duration,
         ) -> AsyncTraceRun<'a> = _run_and_verify_trace_sig
     );
+}
+
+#[cfg(feature = "libsql")]
+fn touch_test_rig_async_sigs() {
+    touch_test_rig_async_message_sigs();
+    touch_test_rig_async_observation_sigs();
+    touch_test_rig_async_trace_sigs();
 }
 
 #[cfg(feature = "libsql")]

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -147,6 +147,11 @@ impl TestChannel {
             .clone()
     }
 
+    /// Return a snapshot of all captured status events without panicking on contention.
+    pub async fn captured_status_events_async(&self) -> Vec<StatusUpdate> {
+        self.status_events.lock().await.clone()
+    }
+
     /// Return the names of all `ToolStarted` events captured so far.
     pub fn tool_calls_started(&self) -> Vec<String> {
         self.captured_status_events()
@@ -161,6 +166,20 @@ impl TestChannel {
     /// Return `(name, success)` for all `ToolCompleted` events captured so far.
     pub fn tool_calls_completed(&self) -> Vec<(String, bool)> {
         self.captured_status_events()
+            .iter()
+            .filter_map(|s| match s {
+                StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return `(name, success)` for all `ToolCompleted` events captured so far.
+    ///
+    /// Prefer this accessor while status events may still be arriving.
+    pub async fn tool_calls_completed_async(&self) -> Vec<(String, bool)> {
+        self.captured_status_events_async()
+            .await
             .iter()
             .filter_map(|s| match s {
                 StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -152,51 +152,49 @@ impl TestChannel {
         self.status_events.lock().await.clone()
     }
 
+    fn filter_status_events<T>(
+        events: &[StatusUpdate],
+        f: impl Fn(&StatusUpdate) -> Option<T>,
+    ) -> Vec<T> {
+        events.iter().filter_map(f).collect()
+    }
+
     /// Return the names of all `ToolStarted` events captured so far.
     pub fn tool_calls_started(&self) -> Vec<String> {
-        self.captured_status_events()
-            .iter()
-            .filter_map(|s| match s {
-                StatusUpdate::ToolStarted { name } => Some(name.clone()),
-                _ => None,
-            })
-            .collect()
+        let events = self.captured_status_events();
+        Self::filter_status_events(&events, |status| match status {
+            StatusUpdate::ToolStarted { name } => Some(name.clone()),
+            _ => None,
+        })
     }
 
     /// Return `(name, success)` for all `ToolCompleted` events captured so far.
     pub fn tool_calls_completed(&self) -> Vec<(String, bool)> {
-        self.captured_status_events()
-            .iter()
-            .filter_map(|s| match s {
-                StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),
-                _ => None,
-            })
-            .collect()
+        let events = self.captured_status_events();
+        Self::filter_status_events(&events, |status| match status {
+            StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),
+            _ => None,
+        })
     }
 
     /// Return `(name, success)` for all `ToolCompleted` events captured so far.
     ///
     /// Prefer this accessor while status events may still be arriving.
     pub async fn tool_calls_completed_async(&self) -> Vec<(String, bool)> {
-        self.captured_status_events_async()
-            .await
-            .iter()
-            .filter_map(|s| match s {
-                StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),
-                _ => None,
-            })
-            .collect()
+        let events = self.captured_status_events_async().await;
+        Self::filter_status_events(&events, |status| match status {
+            StatusUpdate::ToolCompleted { name, success, .. } => Some((name.clone(), *success)),
+            _ => None,
+        })
     }
 
     /// Return `(name, preview)` for all `ToolResult` events captured so far.
     pub fn tool_results(&self) -> Vec<(String, String)> {
-        self.captured_status_events()
-            .iter()
-            .filter_map(|s| match s {
-                StatusUpdate::ToolResult { name, preview } => Some((name.clone(), preview.clone())),
-                _ => None,
-            })
-            .collect()
+        let events = self.captured_status_events();
+        Self::filter_status_events(&events, |status| match status {
+            StatusUpdate::ToolResult { name, preview } => Some((name.clone(), preview.clone())),
+            _ => None,
+        })
     }
 
     /// Return `(name, duration_ms)` for all completed tools with timing data.

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -303,3 +303,60 @@ impl NativeChannel for TestChannel {
         HashMap::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_channel() -> TestChannel {
+        TestChannel::new()
+    }
+
+    /// An empty channel returns an empty snapshot.
+    #[tokio::test]
+    async fn captured_status_events_async_empty() {
+        let channel = make_channel();
+        let events = channel.captured_status_events_async().await;
+        assert!(events.is_empty());
+    }
+
+    /// completed_async returns only ToolCompleted entries.
+    #[tokio::test]
+    async fn tool_calls_completed_async_filters_correctly() {
+        let channel = make_channel();
+
+        channel
+            .send_status(
+                StatusUpdate::ToolStarted {
+                    name: "a".to_string(),
+                },
+                &serde_json::Value::Null,
+            )
+            .await
+            .expect("tool started event should record");
+        channel
+            .send_status(
+                StatusUpdate::ToolCompleted {
+                    name: "b".to_string(),
+                    success: true,
+                    error: None,
+                    parameters: None,
+                },
+                &serde_json::Value::Null,
+            )
+            .await
+            .expect("tool completed event should record");
+
+        let completed = channel.tool_calls_completed_async().await;
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0], ("b".to_string(), true));
+    }
+
+    /// completed_async on an empty channel returns an empty vec.
+    #[tokio::test]
+    async fn tool_calls_completed_async_empty() {
+        let channel = make_channel();
+        let completed = channel.tool_calls_completed_async().await;
+        assert!(completed.is_empty());
+    }
+}

--- a/tests/support/test_rig/rig.rs
+++ b/tests/support/test_rig/rig.rs
@@ -76,6 +76,13 @@ impl TestRig {
         self.channel.tool_calls_completed()
     }
 
+    /// Return `(name, success)` for all `ToolCompleted` events captured so far.
+    ///
+    /// Prefer this accessor while the agent may still be emitting status events.
+    pub async fn tool_calls_completed_async(&self) -> Vec<(String, bool)> {
+        self.channel.tool_calls_completed_async().await
+    }
+
     /// Return `(name, preview)` for all `ToolResult` events captured so far.
     pub fn tool_results(&self) -> Vec<(String, String)> {
         self.channel.tool_results()
@@ -89,6 +96,11 @@ impl TestRig {
     /// Return a snapshot of all captured status events.
     pub fn captured_status_events(&self) -> Vec<StatusUpdate> {
         self.channel.captured_status_events()
+    }
+
+    /// Return a snapshot of all captured status events without panicking on contention.
+    pub async fn captured_status_events_async(&self) -> Vec<StatusUpdate> {
+        self.channel.captured_status_events_async().await
     }
 
     /// Clear all captured responses and status events.

--- a/tests/support/test_rig/rig.rs
+++ b/tests/support/test_rig/rig.rs
@@ -1,3 +1,18 @@
+//! `TestRig` — the central test harness for end-to-end agent tests.
+//!
+//! A `TestRig` wires together an in-process `TestChannel`, an
+//! `InstrumentedLlm`, and (when the `libsql` feature is enabled) a
+//! database and workspace handle. Tests obtain a `TestRig` via
+//! `TestRigBuilder` and drive the agent by calling `send_message`,
+//! `wait_for_responses`, or the trace-replay helpers.
+//!
+//! Synchronous status-event accessors (`tool_calls_completed`,
+//! `captured_status_events`) use `try_lock` and are appropriate when
+//! the agent has already settled. The async variants
+//! (`tool_calls_completed_async`, `captured_status_events_async`) await
+//! the mutex and should be preferred inside polling loops where events
+//! may still be arriving.
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -1,7 +1,7 @@
 //! Thin re-export surface for trace-based test LLM helpers.
 
 pub use super::trace_provider::TraceLlm;
-pub use super::trace_types::{LlmTrace, TraceExpects};
+pub use super::trace_types::{LlmTrace, TraceExpects, load_trace_with_mutation};
 
 #[expect(
     unused_imports,

--- a/tests/support/trace_types.rs
+++ b/tests/support/trace_types.rs
@@ -272,3 +272,64 @@ where
     let trace = serde_json::from_value(value)?;
     Ok(trace)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    fn write_tmp_trace(json: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+        file
+    }
+
+    /// Mutation closure is applied before deserialization.
+    #[tokio::test]
+    async fn mutation_is_applied() {
+        let json = serde_json::json!({"model_name": "test-model", "steps": []}).to_string();
+        let tmp = write_tmp_trace(&json);
+        let mut called = false;
+
+        let trace = load_trace_with_mutation(tmp.path(), |_value| {
+            called = true;
+        })
+        .await
+        .expect("should deserialize");
+
+        assert!(called, "mutation closure must be invoked");
+        assert_eq!(trace.model_name, "test-model");
+    }
+
+    /// Mutation can alter a field in the JSON before the struct is built.
+    #[tokio::test]
+    async fn mutation_modifies_value() {
+        let json = serde_json::json!({"model_name": "original", "steps": []}).to_string();
+        let tmp = write_tmp_trace(&json);
+
+        let trace = load_trace_with_mutation(tmp.path(), |value| {
+            value["model_name"] = serde_json::json!("mutated");
+        })
+        .await
+        .expect("should deserialize");
+
+        assert_eq!(trace.model_name, "mutated");
+    }
+
+    /// A missing file must surface as an error, not a panic.
+    #[tokio::test]
+    async fn missing_file_returns_error() {
+        let result = load_trace_with_mutation("/nonexistent/path/trace.json", |_value| {}).await;
+        assert!(result.is_err(), "missing file must return Err");
+    }
+
+    /// Invalid JSON must surface as an error, not a panic.
+    #[tokio::test]
+    async fn invalid_json_returns_error() {
+        let tmp = write_tmp_trace("not valid json {{");
+        let result = load_trace_with_mutation(tmp.path(), |_value| {}).await;
+        assert!(result.is_err(), "invalid JSON must return Err");
+    }
+}

--- a/tests/support/trace_types.rs
+++ b/tests/support/trace_types.rs
@@ -260,3 +260,15 @@ impl LlmTrace {
         patched
     }
 }
+
+/// Load a trace from JSON, applying a structured mutation before deserializing.
+pub async fn load_trace_with_mutation<F>(path: impl AsRef<Path>, mutate: F) -> Result<LlmTrace>
+where
+    F: FnOnce(&mut serde_json::Value),
+{
+    let contents = tokio::fs::read_to_string(path).await?;
+    let mut value: serde_json::Value = serde_json::from_str(&contents)?;
+    mutate(&mut value);
+    let trace = serde_json::from_value(value)?;
+    Ok(trace)
+}


### PR DESCRIPTION
## What changed
- added a reusable `load_trace_with_mutation` helper that loads a trace fixture into `serde_json::Value`, applies a caller-supplied mutation, and deserializes back to `LlmTrace`
- updated `worker_coverage::tool_error_feedback` to mutate the recovery-path field through an explicit JSON path instead of `patch_path` string replacement
- hardened `advanced_traces::tool_error_recovery` by waiting for a successful `write_file` completion record before reading the recovery file

## Why it changed
String-level fixture patching is brittle and can silently stop matching when fixture formatting or surrounding content changes. Structured JSON mutation makes the intended fixture change explicit and fails loudly if the fixture shape drifts.

The aggregate gate also exposed a timing race in the existing recovery test, so that test now waits for the successful tool completion before asserting on-disk state.

## Impact
- trace-based tests are less fragile around fixture formatting and key ordering
- the worker coverage case documents the exact fixture field it depends on
- the advanced recovery trace is stable under the full test gate

## Validation
- `make all`
- `cargo test --features test-helpers --test e2e_traces advanced_traces::tool_error_recovery -- --exact`
- `cargo test --features test-helpers --test e2e_traces worker_coverage::tool_error_feedback -- --exact`

## Summary by Sourcery

Refactor trace-based tests to use structured JSON mutation and stabilize tool error recovery timing.

New Features:
- Introduce a reusable helper to load trace fixtures as JSON, apply structured mutations, and deserialize back to LlmTrace.

Enhancements:
- Update worker coverage trace tests to mutate the recovery path via an explicit JSON path instead of string replacement.
- Ensure advanced trace recovery tests wait for a successful write_file completion before asserting file contents.
- Expose the new trace mutation helper through the trace LLM support module and validate its signature in test support.

Closes #28

## Summary by Sourcery

Refactor trace-based tests to use structured JSON mutation for fixtures and stabilize tool error recovery timing.

Enhancements:
- Expose a reusable helper to load trace fixtures as JSON, apply a mutation, and deserialize back to LlmTrace through the trace LLM support module.

Tests:
- Update the worker coverage tool_error_feedback test to mutate the recovery path via a structured JSON access instead of string replacement.
- Make the advanced tool_error_recovery trace test wait for a successful write_file completion before validating on-disk recovery output.
- Extend trace support symbol checks to cover the new trace mutation helper signature.