### PR TITLE
Extract shared tool result assertion helper

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -257,7 +257,7 @@ Tests:
 
 - See `src/app.rs` `#[cfg(test)]` for smoke coverage.
 
-### Shared test assertions
+#### Shared test assertions
 
 `tests/support/assertions.rs` is the shared assertion module for trace-driven
 tests. Prefer these helpers when checking captured responses, tool usage, and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -56,7 +56,6 @@ Install these extra tools for work on the compile-time reduction plan:
 branch because `make test` uses it for the root crate. The timing tool
 remains specific to the compile-time reduction work.
 
-
 ## CI build environment
 
 CI jobs in this repository set `CARGO_INCREMENTAL="0"` at the job environment
@@ -74,11 +73,12 @@ the build, an `if: always()` trimming step deletes
 `target/debug/incremental`, `target/debug/.fingerprint`, and `target/**/*.d`
 dependency files before the cache is written back to the action store.
 
-The `gag` crate appears as a `[dev-dependencies]` entry in `Cargo.toml`. It provides
-`gag::BufferRedirect::stdout()` to capture standard output in tests that assert on
-printed startup or boot-screen content — for example, the
-`print_startup_info_matches_snapshot` test in `src/main.rs`. The crate is compiled
-only when running tests and has no effect on the production binary.
+The `gag` crate appears as a `[dev-dependencies]` entry in `Cargo.toml`.
+It provides `gag::BufferRedirect::stdout()` to capture standard output
+in tests that assert on printed startup or boot-screen content — for
+example, the `print_startup_info_matches_snapshot` test in
+`src/main.rs`. The crate is compiled only when running tests and has no
+effect on the production binary.
 
 ## Optional tools by workflow
 
@@ -257,6 +257,28 @@ Tests:
 
 - See `src/app.rs` `#[cfg(test)]` for smoke coverage.
 
+### Shared test assertions
+
+`tests/support/assertions.rs` is the shared assertion module for trace-driven
+tests. Prefer these helpers when checking captured responses, tool usage, and
+tool result previews instead of open-coding assertion logic in each test file.
+
+Common helpers include:
+
+- `assert_response_contains` and `assert_response_not_contains` for
+  case-insensitive response text checks
+- `assert_tools_used`, `assert_tools_not_used`, `assert_tool_order`, and
+  `assert_max_tool_calls` for tool-call sequencing assertions
+- `assert_all_tools_succeeded` and `assert_tool_succeeded` for completed-tool
+  status checks
+- `assert_tool_result_contains` for case-insensitive preview matching against
+  the captured `(tool_name, preview)` results emitted by the test rig
+- `verify_expects` for applying `TraceExpects` fixtures to a captured test run
+
+Keep broad behavioural coverage in the E2E trace fixtures, and place focused
+helper regression tests in `tests/support_unit_tests/assertions_tests.rs` so
+they run once instead of being duplicated across every E2E binary.
+
 #### AppBuilderFlags
 
 `AppBuilderFlags` controls optional construction behaviour:
@@ -355,7 +377,6 @@ artefacts behind on disk.
 Do **not** use `new_local()` in unit tests; reserve it for integration tests
 or tests that specifically require filesystem-path behaviour.
 
-
 ### LibSqlDatabase shared handles
 
 `LibSqlBackend` owns an `Arc<LibSqlDatabase>` rather than a raw libSQL
@@ -420,7 +441,6 @@ loop outcomes into channel outputs. It is decomposed into three layers:
 - Types (`src/agent/dispatcher/types.rs`): pure helpers and simple data
   structures (preview truncation, auth parsing, message compaction,
   etc.).
-
 
 ### Dispatcher and Thread-Operations Module Structure
 
@@ -942,7 +962,6 @@ Tests should pre-bind via `TcpListener::bind("127.0.0.1:0")` and pass the
 result to these helpers instead of relying on `start()` /
 `restart_with_addr()` to pick a free port.
 
-
 ### Workspace store module structure
 
 The libSQL workspace store is split by concern under
@@ -959,7 +978,6 @@ The libSQL workspace store is split by concern under
 Prefer adding logic beside the feature it serves rather than growing
 `mod.rs`. Module-local tests should live with the module they exercise, while
 pipeline tests belong in `workspace/tests.rs`.
-
 
 ### Key APIs
 
@@ -1008,7 +1026,6 @@ through several internal calls. Keep these structs private or `pub(super)`
 unless a wider API boundary genuinely needs them, and prefer names that
 describe the query or scope they model instead of generic `Options` suffixes.
 
-
 #### Parameter objects
 
 The following structs were introduced to keep function arity within the
@@ -1020,7 +1037,6 @@ project's four-argument limit:
 | `TurnPersistContext<'a>` | `thread_id`, `user_id`, `turn_number` | `persist_tool_calls` |
 | `ToolCallSpec<'a>` | `name`, `params` | `execute_chat_tool_standalone` |
 | `ApprovalCandidate` | `idx`, `tool_call`, `tool` | `build_pending_approval` |
-
 
 #### Dispatcher delegate (`src/agent/dispatcher/delegate/`)
 
@@ -1048,4 +1064,3 @@ project's four-argument limit:
 | `hydration.rs` | Lazy thread hydration from the backing store when a known external thread ID is first referenced |
 | `persistence.rs` | Durable write helpers for user messages, assistant responses, and tool-call summaries |
 | `approval.rs` | Resume-from-approval flow after user consent is received |
-

--- a/tests/e2e_traces/workspace_coverage.rs
+++ b/tests/e2e_traces/workspace_coverage.rs
@@ -5,31 +5,9 @@
 
 use std::time::Duration;
 
+use crate::support::assertions::assert_tool_result_contains;
 use crate::support::test_rig::TestRigBuilder;
 use crate::support::trace_llm::LlmTrace;
-
-/// Asserts that at least one result for `tool_name` has a preview
-/// containing any of `expected_substrings`.
-fn assert_tool_result_contains(
-    results: &[(String, String)],
-    tool_name: &str,
-    expected_substrings: &[&str],
-) {
-    let matched: Vec<_> = results
-        .iter()
-        .filter(|(name, _)| name == tool_name)
-        .collect();
-    assert!(
-        !matched.is_empty(),
-        "Expected at least one result for tool '{tool_name}'"
-    );
-    assert!(
-        matched
-            .iter()
-            .any(|(_, preview)| expected_substrings.iter().any(|s| preview.contains(s))),
-        "No result for '{tool_name}' contained any of {expected_substrings:?}: {matched:?}"
-    );
-}
 
 // -----------------------------------------------------------------------
 // Test 1: write_chunk_search

--- a/tests/support/assertions.rs
+++ b/tests/support/assertions.rs
@@ -253,13 +253,11 @@ pub fn verify_expects(
     // tool_results_contain
     for (tool_name, substring) in &expects.tool_results_contain {
         let found = results.iter().find(|(name, _)| name == tool_name);
-        assert!(
-            found.is_some(),
-            "[{label}] tool_results_contain: no result for tool \"{tool_name}\", got: {results:?}"
-        );
-        let (_, preview) = found.expect(
-            "tool result must be present after asserting tool_results_contain lookup succeeded",
-        );
+        let Some((_, preview)) = found else {
+            panic!(
+                "[{label}] tool_results_contain: no result for tool \"{tool_name}\", got: {results:?}"
+            );
+        };
         assert!(
             preview.to_lowercase().contains(&substring.to_lowercase()),
             "[{label}] tool_results_contain: tool \"{tool_name}\" result does not contain \"{substring}\", got: \"{preview}\""

--- a/tests/support/assertions.rs
+++ b/tests/support/assertions.rs
@@ -93,6 +93,7 @@ pub fn assert_tool_succeeded(completed: &[(String, bool)], tool_name: &str) {
 ///
 /// Panics if:
 /// - `expected_substrings` is empty,
+/// - `expected_substrings` contains a blank or whitespace-only entry,
 /// - there are no results for `tool_name`, or
 /// - none of the matching results contain any of the expected substrings.
 pub fn assert_tool_result_contains(
@@ -103,6 +104,12 @@ pub fn assert_tool_result_contains(
     assert!(
         !expected_substrings.is_empty(),
         "expected_substrings must not be empty when asserting tool results for '{tool_name}'"
+    );
+    assert!(
+        expected_substrings
+            .iter()
+            .all(|substring| !substring.trim().is_empty()),
+        "expected_substrings entries must be non-empty when asserting tool results for '{tool_name}'"
     );
 
     let lower_expected: Vec<String> = expected_substrings

--- a/tests/support/assertions.rs
+++ b/tests/support/assertions.rs
@@ -82,12 +82,29 @@ pub fn assert_tool_succeeded(completed: &[(String, bool)], tool_name: &str) {
     );
 }
 
-/// Assert that at least one result for `tool_name` contains an expected substring.
+/// Assert that at least one result for `tool_name` contains an expected
+/// substring, matching case-insensitively.
+///
+/// # Panics
+///
+/// Panics if:
+/// - `expected_substrings` is empty,
+/// - there are no results for `tool_name`, or
+/// - none of the matching results contain any of the expected substrings.
 pub fn assert_tool_result_contains(
     results: &[(String, String)],
     tool_name: &str,
     expected_substrings: &[&str],
 ) {
+    assert!(
+        !expected_substrings.is_empty(),
+        "expected_substrings must not be empty when asserting tool results for '{tool_name}'"
+    );
+
+    let lower_expected: Vec<String> = expected_substrings
+        .iter()
+        .map(|substring| substring.to_lowercase())
+        .collect();
     let matched: Vec<_> = results
         .iter()
         .filter(|(name, _)| name == tool_name)
@@ -97,9 +114,12 @@ pub fn assert_tool_result_contains(
         "Expected at least one result for tool '{tool_name}'"
     );
     assert!(
-        matched
-            .iter()
-            .any(|(_, preview)| expected_substrings.iter().any(|s| preview.contains(s))),
+        matched.iter().any(|(_, preview)| {
+            let lower_preview = preview.to_lowercase();
+            lower_expected
+                .iter()
+                .any(|substring| lower_preview.contains(substring))
+        }),
         "No result for '{tool_name}' contained any of {expected_substrings:?}: {matched:?}"
     );
 }
@@ -233,5 +253,27 @@ pub fn verify_expects(
             preview.to_lowercase().contains(&substring.to_lowercase()),
             "[{label}] tool_results_contain: tool \"{tool_name}\" result does not contain \"{substring}\", got: \"{preview}\""
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::assert_tool_result_contains;
+
+    #[test]
+    fn assert_tool_result_contains_matches_case_insensitively() {
+        let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
+
+        assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
+    )]
+    fn assert_tool_result_contains_rejects_empty_expected_substrings() {
+        let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
+
+        assert_tool_result_contains(&results, "memory_tree", &[]);
     }
 }

--- a/tests/support/assertions.rs
+++ b/tests/support/assertions.rs
@@ -82,8 +82,12 @@ pub fn assert_tool_succeeded(completed: &[(String, bool)], tool_name: &str) {
     );
 }
 
-/// Assert that at least one result for `tool_name` contains an expected
-/// substring, matching case-insensitively.
+/// Assert that at least one preview for `tool_name` contains one of the
+/// `expected_substrings`, matching case-insensitively.
+///
+/// `results` is the captured `(tool_name, preview)` list from the test rig.
+/// The helper first filters to entries for `tool_name`, then succeeds when any
+/// matching preview contains any expected substring.
 ///
 /// # Panics
 ///
@@ -253,27 +257,5 @@ pub fn verify_expects(
             preview.to_lowercase().contains(&substring.to_lowercase()),
             "[{label}] tool_results_contain: tool \"{tool_name}\" result does not contain \"{substring}\", got: \"{preview}\""
         );
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::assert_tool_result_contains;
-
-    #[test]
-    fn assert_tool_result_contains_matches_case_insensitively() {
-        let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
-
-        assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
-    )]
-    fn assert_tool_result_contains_rejects_empty_expected_substrings() {
-        let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
-
-        assert_tool_result_contains(&results, "memory_tree", &[]);
     }
 }

--- a/tests/support/assertions.rs
+++ b/tests/support/assertions.rs
@@ -82,6 +82,28 @@ pub fn assert_tool_succeeded(completed: &[(String, bool)], tool_name: &str) {
     );
 }
 
+/// Assert that at least one result for `tool_name` contains an expected substring.
+pub fn assert_tool_result_contains(
+    results: &[(String, String)],
+    tool_name: &str,
+    expected_substrings: &[&str],
+) {
+    let matched: Vec<_> = results
+        .iter()
+        .filter(|(name, _)| name == tool_name)
+        .collect();
+    assert!(
+        !matched.is_empty(),
+        "Expected at least one result for tool '{tool_name}'"
+    );
+    assert!(
+        matched
+            .iter()
+            .any(|(_, preview)| expected_substrings.iter().any(|s| preview.contains(s))),
+        "No result for '{tool_name}' contained any of {expected_substrings:?}: {matched:?}"
+    );
+}
+
 /// Assert the response does NOT contain any of `forbidden` (case-insensitive).
 pub fn assert_response_not_contains(response: &str, forbidden: &[&str]) {
     let lower = response.to_lowercase();
@@ -204,7 +226,9 @@ pub fn verify_expects(
             found.is_some(),
             "[{label}] tool_results_contain: no result for tool \"{tool_name}\", got: {results:?}"
         );
-        let (_, preview) = found.unwrap();
+        let (_, preview) = found.expect(
+            "tool result must be present after asserting tool_results_contain lookup succeeded",
+        );
         assert!(
             preview.to_lowercase().contains(&substring.to_lowercase()),
             "[{label}] tool_results_contain: tool \"{tool_name}\" result does not contain \"{substring}\", got: \"{preview}\""

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -137,10 +137,7 @@ fn tool_result_contains_ignores_other_tools_when_matching() {
         assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
     });
 
-    assert!(
-        panic.contains("No result for 'memory_tree' contained any of [\"alpha\"]"),
-        "unexpected panic message"
-    );
+    assert_snapshot!(panic);
 }
 
 #[test]

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -24,6 +24,14 @@ fn panic_message(payload: Box<dyn Any + Send>) -> String {
     }
 }
 
+fn assert_panics_with_message<F>(f: F, expected_message: &str)
+where
+    F: FnOnce() + std::panic::UnwindSafe,
+{
+    let payload = catch_unwind(f).expect_err("expected a panic but none occurred");
+    assert_eq!(panic_message(payload), expected_message);
+}
+
 fn capture_panic_message<F>(f: F) -> String
 where
     F: FnOnce() + UnwindSafe,
@@ -136,24 +144,23 @@ fn tool_result_contains_ignores_other_tools_when_matching() {
 fn tool_result_contains_panics_when_tool_is_missing() {
     let results = vec![("memory_search".to_string(), "Alpha/Beta".to_string())];
 
-    let panic = capture_panic_message(|| {
-        assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
-    });
-
-    assert_eq!(panic, "Expected at least one result for tool 'memory_tree'");
+    assert_panics_with_message(
+        AssertUnwindSafe(|| {
+            assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
+        }),
+        "Expected at least one result for tool 'memory_tree'",
+    );
 }
 
 #[test]
 fn tool_result_contains_rejects_empty_expected_substrings() {
     let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
 
-    let panic = capture_panic_message(|| {
-        assert_tool_result_contains(&results, "memory_tree", &[]);
-    });
-
-    assert_eq!(
-        panic,
-        "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
+    assert_panics_with_message(
+        AssertUnwindSafe(|| {
+            assert_tool_result_contains(&results, "memory_tree", &[]);
+        }),
+        "expected_substrings must not be empty when asserting tool results for 'memory_tree'",
     );
 }
 
@@ -178,13 +185,11 @@ fn verify_expects_reports_missing_tool_result_with_label() {
         ..TraceExpects::default()
     };
 
-    let panic = capture_panic_message(|| {
-        verify_expects(&expects, &[], &[], &[], &[], "turn 0");
-    });
-
-    assert_eq!(
-        panic,
-        "[turn 0] tool_results_contain: no result for tool \"memory_tree\", got: []"
+    assert_panics_with_message(
+        AssertUnwindSafe(|| {
+            verify_expects(&expects, &[], &[], &[], &[], "turn 0");
+        }),
+        "[turn 0] tool_results_contain: no result for tool \"memory_tree\", got: []",
     );
 }
 
@@ -196,12 +201,10 @@ fn verify_expects_reports_missing_substring_with_preview() {
     };
     let results = vec![("memory_tree".to_string(), "Gamma/Delta".to_string())];
 
-    let panic = capture_panic_message(|| {
-        verify_expects(&expects, &[], &[], &[], &results, "turn 0");
-    });
-
-    assert_eq!(
-        panic,
-        "[turn 0] tool_results_contain: tool \"memory_tree\" result does not contain \"alpha\", got: \"Gamma/Delta\""
+    assert_panics_with_message(
+        AssertUnwindSafe(|| {
+            verify_expects(&expects, &[], &[], &[], &results, "turn 0");
+        }),
+        "[turn 0] tool_results_contain: tool \"memory_tree\" result does not contain \"alpha\", got: \"Gamma/Delta\"",
     );
 }

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -1,6 +1,21 @@
 //! Assertions helper tests.
 
+use std::any::Any;
+use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
 use crate::support::assertions::*;
+use crate::support::trace_llm::TraceExpects;
+
+fn panic_message(payload: Box<dyn Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "non-string panic payload".to_string(),
+        },
+    }
+}
 
 #[test]
 fn all_tools_succeeded_passes_when_all_true() {
@@ -73,4 +88,99 @@ fn tool_order_panics_for_wrong_order() {
 fn tool_order_panics_for_missing_tool() {
     let started: Vec<String> = vec!["echo".to_string()];
     assert_tool_order(&started, &["echo", "write_file"]);
+}
+
+#[test]
+fn tool_result_contains_matches_case_insensitively() {
+    let results = vec![
+        ("memory_search".to_string(), "irrelevant".to_string()),
+        ("memory_tree".to_string(), "Alpha/Beta".to_string()),
+    ];
+
+    assert_tool_result_contains(&results, "memory_tree", &["alpha", "gamma"]);
+}
+
+#[test]
+fn tool_result_contains_ignores_other_tools_when_matching() {
+    let results = vec![
+        ("memory_search".to_string(), "Alpha/Beta".to_string()),
+        ("memory_tree".to_string(), "Gamma/Delta".to_string()),
+    ];
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
+    }))
+    .expect_err("helper should fail when only another tool matches");
+
+    assert!(
+        panic_message(panic).contains("No result for 'memory_tree' contained any of [\"alpha\"]"),
+        "unexpected panic message"
+    );
+}
+
+#[test]
+fn tool_result_contains_panics_when_tool_is_missing() {
+    let results = vec![("memory_search".to_string(), "Alpha/Beta".to_string())];
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
+    }))
+    .expect_err("helper should fail when the tool is missing");
+
+    assert_eq!(
+        panic_message(panic),
+        "Expected at least one result for tool 'memory_tree'"
+    );
+}
+
+#[test]
+fn tool_result_contains_rejects_empty_expected_substrings() {
+    let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        assert_tool_result_contains(&results, "memory_tree", &[]);
+    }))
+    .expect_err("helper should reject empty expected substrings");
+
+    assert_eq!(
+        panic_message(panic),
+        "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
+    );
+}
+
+#[test]
+fn verify_expects_reports_missing_tool_result_with_label() {
+    let expects = TraceExpects {
+        tool_results_contain: HashMap::from([("memory_tree".to_string(), "alpha".to_string())]),
+        ..TraceExpects::default()
+    };
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        verify_expects(&expects, &[], &[], &[], &[], "turn 0");
+    }))
+    .expect_err("verify_expects should fail when the tool result is missing");
+
+    assert_eq!(
+        panic_message(panic),
+        "[turn 0] tool_results_contain: no result for tool \"memory_tree\", got: []"
+    );
+}
+
+#[test]
+fn verify_expects_reports_missing_substring_with_preview() {
+    let expects = TraceExpects {
+        tool_results_contain: HashMap::from([("memory_tree".to_string(), "alpha".to_string())]),
+        ..TraceExpects::default()
+    };
+    let results = vec![("memory_tree".to_string(), "Gamma/Delta".to_string())];
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        verify_expects(&expects, &[], &[], &[], &results, "turn 0");
+    }))
+    .expect_err("verify_expects should fail when the preview lacks the substring");
+
+    assert_eq!(
+        panic_message(panic),
+        "[turn 0] tool_results_contain: tool \"memory_tree\" result does not contain \"alpha\", got: \"Gamma/Delta\""
+    );
 }

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -1,4 +1,11 @@
-//! Assertions helper tests.
+//! Unit tests for the shared assertion helpers in
+//! [`crate::support::assertions`].
+//!
+//! These tests cover case-insensitive substring matching, per-tool result
+//! filtering, and panic-message diagnostics captured with `catch_unwind`.
+//! They also exercise edge-case guards such as empty
+//! `expected_substrings` inputs and the `TraceExpects`-driven checks in
+//! `verify_expects`.
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -11,6 +11,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, UnwindSafe, catch_unwind};
 
+use insta::assert_snapshot;
 use rstest::rstest;
 
 use crate::support::assertions::*;
@@ -184,12 +185,11 @@ fn verify_expects_reports_missing_tool_result_with_label() {
         ..TraceExpects::default()
     };
 
-    assert_panics_with_message(
-        AssertUnwindSafe(|| {
-            verify_expects(&expects, &[], &[], &[], &[], "turn 0");
-        }),
-        "[turn 0] tool_results_contain: no result for tool \"memory_tree\", got: []",
-    );
+    let message = capture_panic_message(AssertUnwindSafe(|| {
+        verify_expects(&expects, &[], &[], &[], &[], "turn 0");
+    }));
+
+    assert_snapshot!(message);
 }
 
 #[test]
@@ -200,10 +200,9 @@ fn verify_expects_reports_missing_substring_with_preview() {
     };
     let results = vec![("memory_tree".to_string(), "Gamma/Delta".to_string())];
 
-    assert_panics_with_message(
-        AssertUnwindSafe(|| {
-            verify_expects(&expects, &[], &[], &[], &results, "turn 0");
-        }),
-        "[turn 0] tool_results_contain: tool \"memory_tree\" result does not contain \"alpha\", got: \"Gamma/Delta\"",
-    );
+    let message = capture_panic_message(AssertUnwindSafe(|| {
+        verify_expects(&expects, &[], &[], &[], &results, "turn 0");
+    }));
+
+    assert_snapshot!(message);
 }

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -178,31 +178,24 @@ fn tool_result_contains_rejects_invalid_expected_substrings(
     );
 }
 
-#[test]
-fn verify_expects_reports_missing_tool_result_with_label() {
+#[rstest]
+#[case("verify_expects_reports_missing_tool_result_with_label", vec![])]
+#[case(
+    "verify_expects_reports_missing_substring_with_preview",
+    vec![("memory_tree".to_string(), "Gamma/Delta".to_string())]
+)]
+fn verify_expects_reports_tool_result_failure(
+    #[case] snapshot_name: &str,
+    #[case] results: Vec<(String, String)>,
+) {
     let expects = TraceExpects {
         tool_results_contain: HashMap::from([("memory_tree".to_string(), "alpha".to_string())]),
         ..TraceExpects::default()
     };
-
-    let message = capture_panic_message(AssertUnwindSafe(|| {
-        verify_expects(&expects, &[], &[], &[], &[], "turn 0");
-    }));
-
-    assert_snapshot!(message);
-}
-
-#[test]
-fn verify_expects_reports_missing_substring_with_preview() {
-    let expects = TraceExpects {
-        tool_results_contain: HashMap::from([("memory_tree".to_string(), "alpha".to_string())]),
-        ..TraceExpects::default()
-    };
-    let results = vec![("memory_tree".to_string(), "Gamma/Delta".to_string())];
 
     let message = capture_panic_message(AssertUnwindSafe(|| {
         verify_expects(&expects, &[], &[], &[], &results, "turn 0");
     }));
 
-    assert_snapshot!(message);
+    assert_snapshot!(snapshot_name, message);
 }

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -11,6 +11,8 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, UnwindSafe, catch_unwind};
 
+use rstest::rstest;
+
 use crate::support::assertions::*;
 use crate::support::trace_llm::TraceExpects;
 
@@ -152,29 +154,26 @@ fn tool_result_contains_panics_when_tool_is_missing() {
     );
 }
 
-#[test]
-fn tool_result_contains_rejects_empty_expected_substrings() {
+#[rstest]
+#[case(
+    &[],
+    "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
+)]
+#[case(
+    &["   "],
+    "expected_substrings entries must be non-empty when asserting tool results for 'memory_tree'"
+)]
+fn tool_result_contains_rejects_invalid_expected_substrings(
+    #[case] expected_substrings: &'static [&'static str],
+    #[case] expected_message: &str,
+) {
     let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
 
     assert_panics_with_message(
         AssertUnwindSafe(|| {
-            assert_tool_result_contains(&results, "memory_tree", &[]);
+            assert_tool_result_contains(&results, "memory_tree", expected_substrings);
         }),
-        "expected_substrings must not be empty when asserting tool results for 'memory_tree'",
-    );
-}
-
-#[test]
-fn tool_result_contains_rejects_whitespace_only_expected_substrings() {
-    let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
-
-    let panic = capture_panic_message(|| {
-        assert_tool_result_contains(&results, "memory_tree", &["   "]);
-    });
-
-    assert_eq!(
-        panic,
-        "expected_substrings entries must be non-empty when asserting tool results for 'memory_tree'"
+        expected_message,
     );
 }
 

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -27,6 +27,14 @@ fn panic_message(payload: Box<dyn Any + Send>) -> String {
     }
 }
 
+#[test]
+fn panic_message_reports_non_string_payloads() {
+    let payload = catch_unwind(|| std::panic::panic_any(42_u32))
+        .expect_err("panic_any should produce a panic payload");
+
+    assert_eq!(panic_message(payload), "non-string panic payload");
+}
+
 fn assert_panics_with_message<F>(f: F, expected_message: &str)
 where
     F: FnOnce() + std::panic::UnwindSafe,

--- a/tests/support_unit_tests/assertions_tests.rs
+++ b/tests/support_unit_tests/assertions_tests.rs
@@ -9,7 +9,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::panic::{AssertUnwindSafe, UnwindSafe, catch_unwind};
 
 use crate::support::assertions::*;
 use crate::support::trace_llm::TraceExpects;
@@ -22,6 +22,14 @@ fn panic_message(payload: Box<dyn Any + Send>) -> String {
             Err(_) => "non-string panic payload".to_string(),
         },
     }
+}
+
+fn capture_panic_message<F>(f: F) -> String
+where
+    F: FnOnce() + UnwindSafe,
+{
+    let panic = catch_unwind(AssertUnwindSafe(f)).expect_err("helper should panic");
+    panic_message(panic)
 }
 
 #[test]
@@ -114,13 +122,12 @@ fn tool_result_contains_ignores_other_tools_when_matching() {
         ("memory_tree".to_string(), "Gamma/Delta".to_string()),
     ];
 
-    let panic = catch_unwind(AssertUnwindSafe(|| {
+    let panic = capture_panic_message(|| {
         assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
-    }))
-    .expect_err("helper should fail when only another tool matches");
+    });
 
     assert!(
-        panic_message(panic).contains("No result for 'memory_tree' contained any of [\"alpha\"]"),
+        panic.contains("No result for 'memory_tree' contained any of [\"alpha\"]"),
         "unexpected panic message"
     );
 }
@@ -129,29 +136,38 @@ fn tool_result_contains_ignores_other_tools_when_matching() {
 fn tool_result_contains_panics_when_tool_is_missing() {
     let results = vec![("memory_search".to_string(), "Alpha/Beta".to_string())];
 
-    let panic = catch_unwind(AssertUnwindSafe(|| {
+    let panic = capture_panic_message(|| {
         assert_tool_result_contains(&results, "memory_tree", &["alpha"]);
-    }))
-    .expect_err("helper should fail when the tool is missing");
+    });
 
-    assert_eq!(
-        panic_message(panic),
-        "Expected at least one result for tool 'memory_tree'"
-    );
+    assert_eq!(panic, "Expected at least one result for tool 'memory_tree'");
 }
 
 #[test]
 fn tool_result_contains_rejects_empty_expected_substrings() {
     let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
 
-    let panic = catch_unwind(AssertUnwindSafe(|| {
+    let panic = capture_panic_message(|| {
         assert_tool_result_contains(&results, "memory_tree", &[]);
-    }))
-    .expect_err("helper should reject empty expected substrings");
+    });
 
     assert_eq!(
-        panic_message(panic),
+        panic,
         "expected_substrings must not be empty when asserting tool results for 'memory_tree'"
+    );
+}
+
+#[test]
+fn tool_result_contains_rejects_whitespace_only_expected_substrings() {
+    let results = vec![("memory_tree".to_string(), "Alpha/Beta".to_string())];
+
+    let panic = capture_panic_message(|| {
+        assert_tool_result_contains(&results, "memory_tree", &["   "]);
+    });
+
+    assert_eq!(
+        panic,
+        "expected_substrings entries must be non-empty when asserting tool results for 'memory_tree'"
     );
 }
 
@@ -162,13 +178,12 @@ fn verify_expects_reports_missing_tool_result_with_label() {
         ..TraceExpects::default()
     };
 
-    let panic = catch_unwind(AssertUnwindSafe(|| {
+    let panic = capture_panic_message(|| {
         verify_expects(&expects, &[], &[], &[], &[], "turn 0");
-    }))
-    .expect_err("verify_expects should fail when the tool result is missing");
+    });
 
     assert_eq!(
-        panic_message(panic),
+        panic,
         "[turn 0] tool_results_contain: no result for tool \"memory_tree\", got: []"
     );
 }
@@ -181,13 +196,12 @@ fn verify_expects_reports_missing_substring_with_preview() {
     };
     let results = vec![("memory_tree".to_string(), "Gamma/Delta".to_string())];
 
-    let panic = catch_unwind(AssertUnwindSafe(|| {
+    let panic = capture_panic_message(|| {
         verify_expects(&expects, &[], &[], &[], &results, "turn 0");
-    }))
-    .expect_err("verify_expects should fail when the preview lacks the substring");
+    });
 
     assert_eq!(
-        panic_message(panic),
+        panic,
         "[turn 0] tool_results_contain: tool \"memory_tree\" result does not contain \"alpha\", got: \"Gamma/Delta\""
     );
 }

--- a/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__tool_result_contains_ignores_other_tools_when_matching.snap
+++ b/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__tool_result_contains_ignores_other_tools_when_matching.snap
@@ -1,0 +1,6 @@
+---
+source: tests/support_unit_tests/assertions_tests.rs
+assertion_line: 140
+expression: panic
+---
+No result for 'memory_tree' contained any of ["alpha"]: [("memory_tree", "Gamma/Delta")]

--- a/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__verify_expects_reports_missing_substring_with_preview.snap
+++ b/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__verify_expects_reports_missing_substring_with_preview.snap
@@ -1,0 +1,6 @@
+---
+source: tests/support_unit_tests/assertions_tests.rs
+assertion_line: 207
+expression: message
+---
+[turn 0] tool_results_contain: tool "memory_tree" result does not contain "alpha", got: "Gamma/Delta"

--- a/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__verify_expects_reports_missing_tool_result_with_label.snap
+++ b/tests/support_unit_tests/snapshots/support_unit_tests__assertions_tests__verify_expects_reports_missing_tool_result_with_label.snap
@@ -1,0 +1,6 @@
+---
+source: tests/support_unit_tests/assertions_tests.rs
+assertion_line: 192
+expression: message
+---
+[turn 0] tool_results_contain: no result for tool "memory_tree", got: []


### PR DESCRIPTION
## Summary

- move the repeated `assert_tool_result_contains` helper into `tests/support/assertions.rs`
- update `tests/e2e_traces/workspace_coverage.rs` to import the shared helper instead of defining it locally
- replace the remaining bare `.unwrap()` in `verify_expects` with a descriptive `.expect(...)`

## Why

`workspace_coverage.rs` duplicated inline tool-result assertion logic, which makes future changes to the result shape harder to maintain consistently. The bare `.unwrap()` in `verify_expects` also produced weaker diagnostics than the surrounding assertions when CI failures occur.

## Impact

This keeps the test behaviour unchanged while centralising the helper and improving failure messages for expectation checks.

## Validation

- `make all`
  - formatting and linting passed
  - the full test gate failed in unrelated existing `advanced_traces` cases due missing fixture files:
    - `advanced_traces::long_tool_chain`
    - `advanced_traces::user_steering`
- `cargo nextest run --features test-helpers --profile default --test e2e_traces workspace_coverage`

## References

- Closes #27
- Ref: #23

## Summary by Sourcery

Centralise shared test helpers for asserting tool results and improve expectation failure messages.

Enhancements:
- Replace a bare unwrap in verify_expects with a descriptive expect message to improve diagnostics.

Tests:
- Extract the tool result substring assertion into a shared helper in tests/support/assertions.rs and update workspace_coverage tests to use it.

## Summary by Sourcery

Extract a shared test helper for asserting tool result contents and improve diagnostics in expectation verification.

Enhancements:
- Move the tool result substring assertion into the shared test assertions module for reuse across tests.
- Replace a bare unwrap in verify_expects with a descriptive expect message to provide clearer failure diagnostics.

Tests:
- Update workspace_coverage end-to-end trace tests to use the shared tool result assertion helper instead of a local implementation.