### PR TITLE
Bundle builder tool-call payload (#42)

### DIFF
--- a/src/tools/builder/core/build_loop.rs
+++ b/src/tools/builder/core/build_loop.rs
@@ -32,6 +32,11 @@ struct ReasoningBundle {
     ctx: ReasoningContext,
 }
 
+struct ToolCallPayload {
+    tool_calls: Vec<ToolCall>,
+    content: Option<String>,
+}
+
 fn is_completion_signal(lower: &str) -> bool {
     COMPLETION_MARKERS
         .iter()
@@ -231,18 +236,17 @@ impl LlmSoftwareBuilder {
         inputs: &BuildLoopParams,
         bundle: &mut ReasoningBundle,
         state: &mut BuildLoopState,
-        tool_calls: Vec<ToolCall>,
-        content: Option<String>,
+        payload: ToolCallPayload,
     ) {
         bundle
             .ctx
             .messages
             .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
+                payload.content,
+                payload.tool_calls.clone(),
             ));
 
-        for tc in tool_calls {
+        for tc in payload.tool_calls {
             state.logs.push(BuildLog {
                 timestamp: Utc::now(),
                 phase: state.current_phase,
@@ -368,8 +372,16 @@ impl LlmSoftwareBuilder {
                     content,
                 } => {
                     state.tools_executed = true;
-                    self.handle_tool_calls(&inputs, &mut bundle, &mut state, tool_calls, content)
-                        .await;
+                    self.handle_tool_calls(
+                        &inputs,
+                        &mut bundle,
+                        &mut state,
+                        ToolCallPayload {
+                            tool_calls,
+                            content,
+                        },
+                    )
+                    .await;
                 }
             }
         }


### PR DESCRIPTION
## Summary

This branch finishes the issue #42 argument-count refactor in the builder core loop by grouping the remaining tool-call response fields behind a private parameter object.

Closes #42.

## Review walkthrough

- Start with [src/tools/builder/core/build_loop.rs](https://github.com/leynos/axinite/blob/issue-42-argument-count-in-builder-core-loop-helpers/src/tools/builder/core/build_loop.rs) to review the new `ToolCallPayload` parameter object and the updated `handle_tool_calls` signature.
- Then review the `RespondResult::ToolCalls` branch in the same file to confirm the call site now constructs the payload without changing control flow.

## Validation

- `cargo fmt --all`: passed
- `cargo fmt --manifest-path tools-src/github/Cargo.toml --all`: passed
- `make all`: passed
- Local argument-count check: `handle_tool_calls` is 4 explicit parameters, `build_success_result` is 3, `fail_planning_stuck` is 2, `fail_max_iterations` is 2, and the module average is 2.31.

## Notes

- CodeRabbit review was attempted with `coderabbit review --agent`, but the service returned a usage-credit rate-limit error before producing review findings.
- This is a code-only internal refactor; no documentation label is needed because there are no documentation-only changes.

## Summary by Sourcery

Refactor the builder core loop to bundle tool-call response data into a dedicated payload object passed to the tool-call handler.

Enhancements:
- Introduce a ToolCallPayload struct to group tool_calls and content for tool-call handling in the builder loop.
- Update the handle_tool_calls method and its call site to accept the new payload object without changing control flow.