### PR TITLE
Update crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0204 (crossbeam-epoch 0.9.18, published 2026-07-06) fails the dependency audit gate on every non-Dependabot pull request. This change runs `cargo update -p crossbeam-epoch`, moving the sole affected lockfile entry to 0.9.20. No manifest changes are required; the root `Cargo.lock` is the only lockfile that carries the crate.

## Validation

- `cargo audit` with the Makefile's `AUDIT_FLAGS` no longer reports RUSTSEC-2026-0204.

## Out of scope

The audit currently also reports two pre-existing advisories that predate this change and already fail the scheduled audit on `main`:

- RUSTSEC-2026-0187 (high): lopdf 0.34.0 — solution is an upgrade to >=0.42.0.
- RUSTSEC-2026-0188: wasmtime-wasi 44.0.3 — solution is an upgrade to >=45.0.3 or >=46.0.1 (which would likely also allow removing the RUSTSEC-2026-0149 ignore).

These need dependency upgrades rather than a lockfile refresh and are left for follow-up work.
