### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -16,6 +16,13 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
 
   clippy:
     name: Clippy (${{ matrix.name }})

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,199 +1,79 @@
 ---
-name: Mutation Testing
-# Runs cargo-mutants nightly against Rust source files changed in the past
-# 24 hours. Surviving mutants are uploaded as a downloadable artefact and
-# summarised in the job summary. The workflow can also be triggered manually
-# with an explicit list of source-file paths or globs to mutate.
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
 #
 # This workflow is NOT a required status check. Surviving mutants are
 # informational, not a merge gate.
 
 "on":
   schedule:
-    - cron: "0 3 * * *"        # Nightly at 03:00 UTC
+    - cron: "50 10 * * *" # Daily, 10:50 UTC
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to check out and mutate"
-        type: string
-        default: main
-      paths:
-        description: >-
-          Newline-separated list of source file paths or globs to mutate.
-          When empty, the same 24-hour diff logic as the scheduled run is used.
-        type: string
-        default: ""
 
-permissions:
-  contents: read
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
 
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
 concurrency:
   group: mutation-testing-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  mutate:
-    name: Mutation Testing
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      CARGO_INCREMENTAL: "0"
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
-        -C link-arg=-fuse-ld=mold
-    steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: false
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          # workflow_dispatch supplies inputs.branch (default: main).
-          # Scheduled runs fall back to github.ref (the default branch).
-          ref: ${{ inputs.branch || github.ref }}
-          fetch-depth: 0        # Full history required for git log --since
-
-      - name: Compute file list
-        id: compute-files
-        env:
-          INPUT_PATHS: ${{ inputs.paths }}
-        run: |
-          set -euo pipefail
-
-          if [[ -n "$INPUT_PATHS" ]]; then
-            # Manual dispatch with explicit paths: use them directly.
-            CHANGED_FILES="$INPUT_PATHS"
-          else
-            # Scheduled run: find .rs files changed in the past 24 hours.
-            # -m expands merge commits so that files introduced via a
-            # recently-landed merge branch are included even when the
-            # individual side-branch commits are older than 24 hours.
-            CHANGED_FILES=$(
-              git log -m --since="24 hours ago" \
-                --diff-filter=ACMR --name-only --pretty=format: HEAD \
-              | grep '\.rs$' | sort -u || true
-            )
-          fi
-
-          # Exclude out-of-tree crates from the mutation scope.
-          # tools-src/ and channels-src/ use separate manifests and are
-          # not workspace members; cargo-mutants cannot target them.
-          CHANGED_FILES=$(
-            printf '%s\n' "$CHANGED_FILES" \
-            | grep -v -E '^(tools-src|channels-src)/' \
-            || true
-          )
-
-          if [[ -z "$CHANGED_FILES" ]]; then
-            echo "No Rust source files changed in the past 24 hours." \
-              "Skipping mutation run."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Files selected for mutation testing:"
-            echo "$CHANGED_FILES"
-            {
-              echo "files<<EOF"
-              echo "$CHANGED_FILES"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install Rust
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-wasip2
-
-      - name: Install mold
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: rui314/setup-mold@v1
-
-      - name: Rust cache
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: mutation-testing
-
-      - name: Install cargo-mutants
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: taiki-e/install-action@cargo-mutants
-
-      - name: Install cargo-nextest
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: taiki-e/install-action@cargo-nextest
-
-      - name: Install cargo-component
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-component
-
-      - name: Build GitHub WASM tool (for metadata/schema tests)
-        if: steps.compute-files.outputs.skip != 'true'
-        run: make build-github-tool-wasm
-
-      - name: Build WASM channels (for integration tests)
-        if: steps.compute-files.outputs.skip != 'true'
-        run: ./scripts/build-wasm-extensions.sh --channels
-
-      - name: Run cargo-mutants
-        if: steps.compute-files.outputs.skip != 'true'
-        id: run-mutants
-        # continue-on-error so surviving mutants do not fail the job.
-        # Surviving mutants are informational; the artefact and summary
-        # steps below capture the results regardless of exit code.
-        continue-on-error: true
-        env:
-          FILES: ${{ steps.compute-files.outputs.files }}
-        run: |
-          set -euo pipefail
-
-          file_args=""
-          while IFS= read -r f; do
-            [[ -n "$f" ]] && file_args+=" --file $f"
-          done <<< "$FILES"
-
-          # shellcheck disable=SC2086
-          cargo mutants --no-shuffle --test-tool nextest \
-            --timeout-multiplier 3 \
-            --features test-helpers \
-            ${file_args}
-
-      - name: Print surviving mutants summary
-        if: steps.compute-files.outputs.skip != 'true'
-        run: |
-          echo "## Surviving mutants" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -s mutants.out/survived.txt ]]; then
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat mutants.out/survived.txt >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No surviving mutants." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload mutation report
-        if: steps.compute-files.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: mutants-report
-          path: mutants.out/
-          retention-days: 14
-          # Prevent a hard failure if cargo-mutants exits before creating
-          # the output directory (e.g. internal error or misconfiguration).
-          if-no-files-found: ignore
-
-      - name: Trim build artefacts before cache save
-        if: always()
-        run: |
-          rm -rf target/debug/incremental
-          rm -rf target/debug/.fingerprint
-          cargo clean --doc 2>/dev/null || true
-          find target -name "*.d" -delete 2>/dev/null || true
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      # Mutate only the root ironclaw crate. tools-src/, channels-src/
+      # and fuzz/ sit outside the workspace (root Cargo.toml excludes
+      # them), and the vendored grammers-crypto patch crate under
+      # tools-src/telegram/patches/ must never be mutated.
+      paths: "src/"
+      # Test-support scaffolding compiled into non-test builds, whose
+      # survivors are noise. src/tools/builder/testing.rs is production
+      # code (the built-tool testing pipeline phase) and stays in scope.
+      exclude-globs: >-
+        src/testing/**,src/testing_wasm.rs,src/skills/test_support.rs,src/channels/web/test_helpers.rs
+      # Mirror the CI default test leg (make test runs with
+      # --features test-helpers on top of default features); the CI
+      # baseline is workspace-wide (nextest --workspace), so run
+      # workspace tests against each mutant. Test with nextest, not
+      # plain cargo test: the startup boot-screen snapshot test
+      # captures stdout at file-descriptor level (gag), which needs
+      # process-per-test isolation, so the plain cargo test baseline
+      # fails (issue #237); the previous bespoke mutation workflow
+      # also ran nextest. The passthrough filter drops the
+      # schema_helpers_ui trybuild binary from per-mutant runs: it
+      # recompiles the crate inside its own sandbox for every case,
+      # dominating per-mutant runtime while asserting compile-time
+      # contracts that mutants do not usefully exercise (the larger
+      # trybuild binary is already excluded by the default nextest
+      # profile).
+      extra-args: >-
+        --features test-helpers --test-workspace=true
+        --test-tool=nextest --
+        -E "not binary(schema_helpers_ui)"
+      # Heavy crate (~760 source files atop wasmtime/libsql); eight
+      # shards keep full dispatch legs inside the step timeout.
+      shard-count: 8
+      # Mirror the CI test environment (test.yml "Tests" job): free
+      # runner disk, the clang+mold linker demanded by
+      # .cargo/config.toml, the wasm32-wasip2 target, cargo-component,
+      # and the prebuilt WASM artefacts the integration tests load
+      # (the Telegram channel tests hard-fail in CI when absent).
+      setup-commands: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup
+        sudo apt-get update
+        sudo apt-get install -y clang mold
+        rustup target add wasm32-wasip2
+        cargo binstall --no-confirm cargo-component cargo-nextest
+        make build-github-tool-wasm
+        ./scripts/build-wasm-extensions.sh --channels

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ trace_*.json
 
 # Pending snapshot files (transient test artifacts)
 *.pending-snap
+
+# Python bytecode caches (workflow contract tests)
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ AUDIT_FLAGS ?= \
 	--ignore RUSTSEC-2024-0370 \
 	--ignore RUSTSEC-2025-0134
 
-.PHONY: all install install-with-overrides sync-local-wasm-overrides build-github-tool-wasm check-fmt typecheck lint markdownlint audit rust-audit test test-cargo test-matrix test-matrix-cargo clean
+.PHONY: all install install-with-overrides sync-local-wasm-overrides build-github-tool-wasm check-fmt typecheck lint markdownlint audit rust-audit test test-cargo test-matrix test-matrix-cargo test-workflow-contracts clean
 
 all: check-fmt lint test
 
@@ -120,6 +120,10 @@ test-matrix-cargo:
 	$(CARGO) test --no-default-features --features libsql-test-helpers -- --nocapture
 	$(CARGO) test --features postgres,libsql-test-helpers,html-to-markdown -- --nocapture
 	$(CARGO) test --manifest-path $(GITHUB_TOOL_MANIFEST) -- --nocapture
+
+# Validate the mutation-testing caller workflow contract.
+test-workflow-contracts:
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 clean:
 	$(CARGO) clean

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,206 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; axinite's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the root-crate scoping that
+keeps the vendored grammers-crypto patch crate and the out-of-workspace
+tools-src/ and channels-src/ crates out of mutation) fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW_PATH.exists(),
+    reason="workflow file not present in this working copy (e.g. "
+    "inside a mutation-testing sandbox that does not copy .github/)",
+)
+
+#: The pinned commit of leynos/shared-actions carrying the
+#: setup-commands input, the python-version fail-fast guard, and
+#: step-level timeout artefact preservation. Bump the caller and this
+#: test together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: Test-support scaffolding compiled into non-test builds; mutants
+#: there survive as noise. src/tools/builder/testing.rs is production
+#: code and must NOT appear here.
+SCAFFOLDING_EXCLUDES = (
+    "src/testing/**",
+    "src/testing_wasm.rs",
+    "src/skills/test_support.rs",
+    "src/channels/web/test_helpers.rs",
+)
+
+#: Commands the setup block must run so mutants see the same
+#: environment as CI's test job (test.yml).
+REQUIRED_SETUP_FRAGMENTS = (
+    "apt-get install -y clang mold",
+    "rustup target add wasm32-wasip2",
+    "cargo binstall --no-confirm cargo-component cargo-nextest",
+    "make build-github-tool-wasm",
+    "./scripts/build-wasm-extensions.sh --channels",
+)
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses a bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the test and the workflow together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "50 10 * * *"}], (
+        f"on.schedule must be the daily 10:50 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the axinite-specific configuration."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert set(with_block) == {
+        "paths",
+        "exclude-globs",
+        "extra-args",
+        "shard-count",
+        "setup-commands",
+    }, (
+        "jobs.mutation.with must set exactly paths, exclude-globs, "
+        f"extra-args, shard-count and setup-commands, got {sorted(with_block)}"
+    )
+    assert with_block.get("paths") == "src/", (
+        "with.paths must scope mutation to the root crate only, keeping "
+        "the out-of-workspace tools-src/ and channels-src/ crates (and the "
+        "vendored grammers-crypto patch) out of scope, got "
+        f"{with_block.get('paths')!r}"
+    )
+    excludes = with_block.get("exclude-globs")
+    assert isinstance(excludes, str), "with.exclude-globs is missing"
+    assert sorted(g.strip() for g in excludes.split(",")) == sorted(
+        SCAFFOLDING_EXCLUDES
+    ), (
+        f"with.exclude-globs must cover exactly {SCAFFOLDING_EXCLUDES}, "
+        f"got {excludes!r}"
+    )
+    assert with_block.get("extra-args") == (
+        "--features test-helpers --test-workspace=true "
+        '--test-tool=nextest -- -E "not binary(schema_helpers_ui)"'
+    ), (
+        "with.extra-args must mirror the CI default test leg "
+        "(--features test-helpers), run workspace tests against each "
+        "mutant, use nextest as the test tool (the boot-screen snapshot "
+        "test needs process-per-test isolation, issue #237), and drop "
+        "the slow schema_helpers_ui trybuild binary from per-mutant "
+        f"runs, got {with_block.get('extra-args')!r}"
+    )
+    assert with_block.get("shard-count") == 8, (
+        f"with.shard-count must be 8 (heavy wasmtime/libsql build; keep "
+        f"dispatch legs inside the step timeout), got "
+        f"{with_block.get('shard-count')!r}"
+    )
+    setup = with_block.get("setup-commands")
+    assert isinstance(setup, str), "with.setup-commands is missing"
+    for fragment in REQUIRED_SETUP_FRAGMENTS:
+        assert fragment in setup, (
+            f"with.setup-commands must run {fragment!r} to mirror the CI "
+            f"test environment, got {setup!r}"
+        )


### PR DESCRIPTION
## Summary

Enrols axinite in the estate-wide scheduled mutation testing rollout by replacing the bespoke nightly cargo-mutants workflow with a thin caller of the [`mutation-cargo.yml` reusable workflow](https://github.com/leynos/shared-actions/blob/main/.github/workflows/mutation-cargo.yml), pinned to `859416a90eb3987b46a57682c5d6b8964ad3f0a6`. Runs are informational only (never a merge gate): a daily guard at 10:50 UTC mutates just the files changed within the detection window, while manual dispatch mutates everything fanned out across shards. See the [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template PR leynos/wireframe#572.

## Configuration rationale

- **`paths: "src/"`** — only the root `ironclaw` crate is a mutation target. The sixteen other cargo directories (`channels-src/*`, `tools-src/*`, `fuzz/`) all sit outside the workspace (`[workspace] members = ["."]`), which keeps the vendored grammers-crypto patch crate under `tools-src/telegram/patches/` firmly out of scope. This matches the previous bespoke workflow, which also excluded `tools-src/` and `channels-src/`.
- **`exclude-globs`** — `src/testing/**`, `src/testing_wasm.rs`, `src/skills/test_support.rs` and `src/channels/web/test_helpers.rs` are test-support scaffolding compiled into non-test builds (feature-gated on `test-helpers` or deliberately always compiled); their survivors are noise. `src/tools/builder/testing.rs` is production code (the built-tool testing pipeline phase) and deliberately stays in scope.
- **`extra-args`** — `--features test-helpers` mirrors the CI default test leg (`make test`); `--test-workspace=true` matches the workspace-wide CI baseline (`nextest run --workspace`); `--test-tool=nextest` is required because the startup boot-screen snapshot test captures stdout at file-descriptor level with `gag`, which needs nextest's process-per-test isolation and fails under plain `cargo test` (#237) — the bespoke workflow also ran nextest. The passthrough `-E "not binary(schema_helpers_ui)"` drops a trybuild binary that recompiles the crate inside its own sandbox (~6 minutes locally) per run while asserting compile-time contracts mutants do not usefully exercise; with it excluded the per-mutant suite runs in ~24 seconds locally.
- **`shard-count: 8`** — heavy crate (~760 source files atop wasmtime/libsql); extra shards keep full dispatch legs inside the step timeout (precedent: wireframe).
- **`setup-commands`** — mirrors CI's test job (`test.yml`): frees runner disk, installs clang and mold (the linker `.cargo/config.toml` demands), adds the `wasm32-wasip2` target, installs cargo-component and cargo-nextest, and prebuilds the GitHub tool and channel WASM artefacts that integration tests load (the Telegram channel tests hard-fail in CI when the artefact is absent).

A contract test, run via `make test-workflow-contracts` and wired into the Formatting job of the Code Style workflow, pins the SHA, permissions, concurrency, schedule and the full `with:` block so drift fails PR CI.

## Baseline verification

- Plain `CI=1 cargo test --features test-helpers` **fails** locally on `startup::boot::tests::print_startup_info_matches_snapshot` (fd-level stdout capture yields an empty string under libtest's in-process capture). Filed as #237; this is why the caller keeps nextest as the test tool rather than cargo-mutants' plain-cargo-test default.
- `CI=1 cargo nextest run --workspace --features test-helpers` passes: 4238/4238 (405 s, dominated by `schema_helpers_ui`).
- With the exact per-mutant filter (`-E "not binary(schema_helpers_ui)"`): 4237/4237 in 23.6 s, and a consecutive rerun stays green (no rerun-state hazard).
- Both runs used prebuilt `github_tool.wasm` and `telegram_channel.wasm` artefacts, exercising (not skipping) the WASM integration tests.

## Validation

- YAML parses ([mutation-testing.yml](https://github.com/leynos/axinite/blob/add-mutation-testing/.github/workflows/mutation-testing.yml), [code_style.yml](https://github.com/leynos/axinite/blob/add-mutation-testing/.github/workflows/code_style.yml)); actionlint clean on both.
- [Contract tests](https://github.com/leynos/axinite/blob/add-mutation-testing/tests/workflow_contracts/mutation_testing_test.py): 6/6 pass, including a negative test (repointing the pin at `@v1` fails the SHA assertion).

## Known red CI (pre-existing)

The Dependency Audit job fails on advisories unrelated to this diff: RUSTSEC-2026-0204 (crossbeam-epoch, fixed by #236), plus pre-existing RUSTSEC-2026-0187 (lopdf 0.34.0) and RUSTSEC-2026-0188 (wasmtime-wasi 44.0.3), which already fail the scheduled audit on `main` and need dependency upgrades rather than a lockfile refresh.
