### PR TITLE
Wire CodeScene coverage upload on main and unify shared-actions pin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,11 @@ name: Code Coverage
 "on":
   push:
     branches: [main]
+  # Allow the CodeScene upload to be re-run on demand. Merges performed
+  # by the automerge workflow's GITHUB_TOKEN do not fire push-event
+  # workflows, so automerged changes to main only receive a CodeScene
+  # upload via this manual dispatch.
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -139,6 +144,25 @@ jobs:
           cargo llvm-cov ${{ matrix.flags }} --features test-helpers
           --workspace --lcov
           --output-path lcov.info
+
+      # Feed CodeScene's stored coverage from the analysed branch (main).
+      # Upload from ONE leg only (all-features, the broadest suite) so
+      # CodeScene receives a single report per commit. The guard skips
+      # the step when the project access token is absent (forks). The
+      # PR "Code Coverage" gate (mode: check) is deferred until the
+      # CodeScene project's gates configuration is enabled operator-side
+      # (project 77987 posts only Code Health Review today).
+      - name: Upload coverage to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: matrix.name == 'all-features' && env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: upload
+          project-url: https://api.codescene.io/v2/projects/77987
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Mutate only the root ironclaw crate. tools-src/, channels-src/
       # and fuzz/ sit outside the workspace (root Cargo.toml excludes

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -31,9 +31,10 @@ pytestmark = pytest.mark.skipif(
 
 #: The pinned commit of leynos/shared-actions carrying the
 #: setup-commands input, the python-version fail-fast guard, and
-#: step-level timeout artefact preservation. Bump the caller and this
-#: test together.
-PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+#: step-level timeout artefact preservation. Bumped to the estate-wide
+#: coverage floor (927edd4), which carries the mutation-cargo workflow
+#: unchanged. Bump the caller and this test together.
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Onboards axinite to the CodeScene coverage upload, keeping the repo's
bespoke coverage generation intact.

- **Keep bespoke generation, wire only the upload (lading-style).** The
  coverage pipeline here is deeply repo-specific — three feature-matrix
  legs plus a separate e2e coverage job, WASM prebuilds
  (`build-github-tool-wasm`, `build-wasm-extensions.sh`),
  `cargo-component`, Postgres services with migrations, and the
  clang+mold linker from `.cargo/config.toml`. The shared
  `generate-coverage` action knows none of that, so migrating would be a
  large, high-risk rewrite for no coverage-quality gain. This PR adds
  only a guarded `upload-codescene-coverage` step to the existing
  push-to-main [`coverage.yml`](../blob/codescene-coverage-gate/.github/workflows/coverage.yml),
  leaving the proven Codecov flow untouched.
- The upload runs from the **all-features leg only** so CodeScene
  receives a single report per commit; the token guard skips it on forks.
- Adds a **`workflow_dispatch`** trigger to `coverage.yml`: merges
  performed by the automerge workflow's `GITHUB_TOKEN` do not fire
  push-event workflows, so automerged changes to main would otherwise
  never receive a CodeScene upload.
- **The PR-side changed-line gate (`mode: check`) is deferred.**
  CodeScene project 77987 posts only a `Code Health Review` today and
  its gates configuration is not enabled, so `mode: check` would fail
  unconditionally ("Lacks the gates configuration"). It can be added in a
  fast follow once the gate is switched on operator-side. This is CI
  wiring only; the CodeScene "Code Coverage" PR check is enabled
  per-project in CodeScene's UI.
- **Single repo-wide shared-actions pin at `927edd4`** (the estate
  coverage floor): bumps the `mutation-cargo` caller (byte-identical at
  that SHA) and the `dependabot-automerge` caller (internal action-SHA
  bumps only), and updates the mutation-testing contract test to match.
  This supersedes open Dependabot PR #234, which targets an ancestor of
  the floor.

## Review walkthrough

- [`.github/workflows/coverage.yml`](../blob/codescene-coverage-gate/.github/workflows/coverage.yml)
  — `workflow_dispatch` trigger; guarded CodeScene upload after
  `Generate coverage`, scoped to `matrix.name == 'all-features'`.
- [`.github/workflows/mutation-testing.yml`](../blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and
  [`.github/workflows/dependabot-automerge.yml`](../blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — pin bump to `927edd4`.
- [`tests/workflow_contracts/mutation_testing_test.py`](../blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py)
  — `PINNED_SHA` bumped in lockstep.

## Ratchet

Not enabled. The coverage ratchet is a feature of the shared
`generate-coverage` action, which this repo does not adopt (bespoke
`cargo llvm-cov`). There is no ratchet to wire without migrating
generation, which is out of scope here.

## Note on the status rollup

The CodeScene "Code Coverage" check is **not** a required status check in
this repo's ruleset; it blocks via the PR status rollup, not the ruleset.
No required check context is renamed by this PR ("Code Style (fmt +
clippy)", "Run Tests", and "Regression test enforcement" are untouched).

## Validation

- `python3 -c "import yaml; ..."` parses all three changed workflows.
- `make test-workflow-contracts` — 6 passed (pinned-SHA contract updated
  in the same commit).
- The bespoke coverage job runs only on push to main and manual
  dispatch, so no PR-side upload step exists to break when the secret is
  set (no sequencing trap).
