### PR TITLE
Install clang in the coverage job so main coverage builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -95,6 +95,12 @@ jobs:
           components: llvm-tools-preview
           targets: wasm32-wasip2
 
+      # The free-disk-space step above removes large apt packages,
+      # including the clang the CARGO_..._LINKER env demands. Reinstall
+      # it (as test.yml does) so the host build scripts link.
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+
       - name: Install mold
         uses: rui314/setup-mold@v1
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing failure in the `Code Coverage` workflow on `main`,
which has broken on every push since at least 2026-07-09.

The `coverage` job frees disk space with `large-packages: true`, which
removes the `clang` that `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER`
requires. The subsequent `make build-github-tool-wasm` step then fails
with `error: linker \`clang\` not found` before coverage is ever
generated. The `tests` job avoids this by carrying an explicit
`Install clang` step after its own free-disk-space step; the coverage
job was missing it.

This step reinstalls `clang` immediately after the toolchain, mirroring
`test.yml`. It unblocks the CodeScene upload wired in #240, which sits
after `Generate coverage` and so never ran while the job died early.

## Review walkthrough

- [`.github/workflows/coverage.yml`](../blob/coverage-install-clang/.github/workflows/coverage.yml)
  — one `Install clang` step in the `coverage` job.

## Validation

- `python3 -c "import yaml; ..."` parses `coverage.yml`.
- `make test-workflow-contracts` — 6 passed.
- Confirmed the failure on run 29296107229 (the merge of #240):
  `error: linker \`clang\` not found` at `Build GitHub WASM tool`.

## Out of scope

The separate `E2E Coverage` job fails later, at `Run E2E tests`
(pytest), for an unrelated pre-existing reason; that is not addressed
here.
