### PR TITLE
Generate coverage with nextest and upload the libsql leg to CodeScene

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+
       - name: Install cargo-component
         uses: taiki-e/install-action@v2
         with:
@@ -139,15 +142,26 @@ jobs:
           PGPASSWORD: postgres
           PGDATABASE: ironclaw_test
 
-      - name: Set DATABASE_URL for postgres configs
+      - name: Set database URLs for postgres configs
         if: matrix.has_postgres
         run: |
           database_url="postgres://postgres:postgres@localhost/ironclaw_test"
           echo "DATABASE_URL=${database_url}" >> "$GITHUB_ENV"
+          # The Postgres test harness (src/testing/postgres.rs) reads
+          # TEST_DATABASE_URL, not DATABASE_URL; without credentials it
+          # falls back to a password-less URL and every Postgres test
+          # panics with "password missing" instead of connecting.
+          echo "TEST_DATABASE_URL=${database_url}" >> "$GITHUB_ENV"
 
+      # Instrument with nextest, not plain `cargo test`: the startup
+      # boot-screen snapshot test captures stdout at file-descriptor
+      # level (gag) and needs nextest's process-per-test isolation, so
+      # the `cargo test` baseline llvm-cov drives otherwise fails
+      # (issue #237). nextest also skips doctests; the default profile
+      # additionally drops the slow trybuild binaries.
       - name: Generate coverage
         run: >-
-          cargo llvm-cov ${{ matrix.flags }} --features test-helpers
+          cargo llvm-cov nextest ${{ matrix.flags }} --features test-helpers
           --workspace --lcov
           --output-path lcov.info
 


### PR DESCRIPTION
## Summary

Second follow-up to the CodeScene onboarding (after #240 wired the
upload and #241 restored `clang`). With `clang` back, the `Generate
coverage` step finally reached the test run on `main` and exposed
pre-existing failures that the earlier build-time errors had masked.

- **Instrument with nextest (issue #237).** The startup boot-screen
  snapshot test captures stdout at file-descriptor level (`gag`) and
  needs process-per-test isolation, so it panics under the plain
  `cargo test` that `cargo llvm-cov` drives by default. This switches
  generation to `cargo llvm-cov nextest`, matching the `tests` and
  mutation workflows; `cargo-nextest` is installed in the job, and the
  default nextest profile also drops the slow trybuild binaries.
- **Upload the libsql-only leg.** This is the leg that reliably builds
  a coverage report, so the guarded CodeScene upload moves from
  `all-features` to `libsql-only`.

## Why not the broader legs?

The postgres-bearing legs (`default`, `all-features`) fail their
Postgres integration tests for reasons unrelated to coverage wiring, and
those failures predate this work:

- Those tests have **never run against a migrated database in CI** — the
  `tests` job has no Postgres service, so `try_test_pg_db` skips them on
  connection-refused. The coverage job *does* provide a service, so they
  run for the first time.
- At least one is simply buggy against the real schema:
  `history::store::llm_calls::tests::record_llm_call_persists_expected_values`
  inserts an `llm_call` for a random `job_id` with no parent `jobs` row,
  violating `llm_calls_job_id_fkey`.

Repairing those tests (and confirming the set is parallel-safe under
nextest against a shared database) is a separate, maintainer-owned task.
Once done, the upload can move to `all-features` for broader coverage.
The libsql-only report is a correct, if narrower, baseline for
CodeScene's stored coverage in the meantime.

## Review walkthrough

- [`.github/workflows/coverage.yml`](../blob/coverage-generation-repair/.github/workflows/coverage.yml)
  — install `cargo-nextest`; `cargo llvm-cov nextest`; move the upload
  guard to `matrix.name == 'libsql-only'`.

## Validation

- `python3 -c "import yaml; ..."` parses `coverage.yml`;
  `make test-workflow-contracts` — 6 passed.
- A `workflow_dispatch` run of `Code Coverage` on this branch confirmed
  the `libsql-only` leg now builds the coverage report successfully
  (Generate coverage: success). The `all-features`/`default` legs fail on
  the pre-existing Postgres test issues described above.

## Out of scope

The `E2E Coverage` job still fails at `Run E2E tests` (pytest), a
pre-existing failure unrelated to Rust coverage generation.
