### PR TITLE
Drop exact-SHA pin from mutation-testing contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -80,6 +80,41 @@ example, the
 `print_startup_info_matches_snapshot` test in `src/startup/boot.rs`. The crate
 is compiled only when running tests and has no effect on the production binary.
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## 6. Optional tools by workflow
 
 These tools are not required for every contributor, but they are needed

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -7,13 +7,17 @@ PyYAML and pin the contract it must uphold, so drift (repointing the pin
 at a branch, widening permissions, or losing the root-crate scoping that
 keeps the vendored grammers-crypto patch crate and the out-of-workspace
 tools-src/ and channels-src/ crates out of mutation) fails CI on the
-pull request rather than surfacing in a scheduled or manual run.
+pull request rather than surfacing in a scheduled or manual run. The
+caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so these tests assert the shape of the
+pin rather than the exact commit.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -29,15 +33,11 @@ pytestmark = pytest.mark.skipif(
     "inside a mutation-testing sandbox that does not copy .github/)",
 )
 
-#: The pinned commit of leynos/shared-actions carrying the
-#: setup-commands input, the python-version fail-fast guard, and
-#: step-level timeout artefact preservation. Bumped to the estate-wide
-#: coverage floor (927edd4), which carries the mutation-cargo workflow
-#: unchanged. Bump the caller and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: Matches the mutation-cargo caller pinned to a full 40-hex commit SHA.
+#: Dependabot owns the SHA value; this asserts the workflow path and
+#: pin shape only, not which commit is pinned.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: Test-support scaffolding compiled into non-test builds; mutants
@@ -84,25 +84,15 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the test and the workflow together"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-cargo.yml "
+        f"pinned to a full 40-character lowercase-hex commit SHA (not a "
+        f"branch or tag), got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing caller workflow contract test asserted an exact
  `leynos/shared-actions` commit SHA (`927edd4...`), so every Dependabot
  bump of `jobs.mutation.uses` in `.github/workflows/mutation-testing.yml`
  failed CI until a human hand-edited the pinned constant to match.
- Replace the exact-SHA equality assertion with a shape assertion: the
  caller must still reference `mutation-cargo.yml` pinned to a full
  40-hex-character commit SHA (never a mutable branch/tag such as
  `main`), but the specific SHA value is no longer part of the contract.
  Dependabot now owns bumping it without a lockstep test edit.
- All other structural guards in the test file are unchanged: job
  permissions, workflow-level default permissions, concurrency, triggers,
  and the `with:` block (paths, exclude-globs, extra-args, shard-count,
  setup-commands).
- Document the shape-not-value convention in `docs/developers-guide.md`
  under a new "Workflow pins and Dependabot" subsection of §5 (CI build
  environment), so future contract tests in this repo follow the same
  pattern.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry
  with `directory: "/"`, weekly schedule — no change needed there.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: drop `PINNED_SHA`
  / `EXPECTED_USES` and the "bump the workflow and this test together"
  doc-comment; add a `USES_RE` pattern
  (`^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`)
  and rename the test to `test_uses_reference_is_pinned_to_a_commit_sha`,
  asserting the reference matches the pattern instead of an exact string.
  Update the module docstring to describe the contract as "correct
  reusable workflow at a commit SHA; Dependabot owns the SHA value".
- `docs/developers-guide.md`: add the policy subsection (rationale, dos
  and don'ts, and a short example) so contributors writing future
  workflow contract tests know not to reintroduce an exact-SHA pin.
- The workflow files themselves (`.github/workflows/mutation-testing.yml`,
  `coverage.yml`) are untouched — this PR only relaxes the test and adds
  documentation.

## Validation

- `make test-workflow-contracts` — 6 passed (confirms the new regex
  matches the currently pinned SHA).
- Reasoned through the regex against a hypothetical different 40-hex SHA
  and a branch ref (`@main`): matches the former, rejects the latter, so
  a future Dependabot bump PR will not fail this test.
- `make markdownlint` — 0 errors on the changed `docs/developers-guide.md`.
