### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -50,7 +50,7 @@ jobs:
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
         -C link-arg=-fuse-ld=mold
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
       # The suite's default toolchain (nightly-2025-09-18) predates rustc
       # 1.93, which wasmtime 45 requires, so the installer builds the suite
       # against a late 1.93-cycle nightly instead.

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -51,10 +51,6 @@ jobs:
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: >-
         -C link-arg=-fuse-ld=mold
       WHITAKER_INSTALLER_VERSION: '0.2.6'
-      # The suite's default toolchain (nightly-2025-09-18) predates rustc
-      # 1.93, which wasmtime 45 requires, so the installer builds the suite
-      # against a late 1.93-cycle nightly instead.
-      WHITAKER_TOOLCHAIN: nightly-2025-12-10
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +100,7 @@ jobs:
               cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
             fi
           fi
-          whitaker-installer --toolchain "${WHITAKER_TOOLCHAIN}"
+          whitaker-installer
       - name: Whitaker Dylint suite
         if: matrix.whitaker
         run: make lint-whitaker


### PR DESCRIPTION
This bumps the pinned `whitaker-installer` version in `.github/workflows/code_style.yml` from `0.2.5` to `0.2.6`.

Whitaker's rolling-release Dylint suite now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` `6.0.1`. Installer `0.2.5` provisions `cargo-dylint` `4.1.0`, whose dylint driver cannot compile on that nightly, so the `clippy` job's Whitaker install step has been failing. `whitaker-installer` `0.2.6` provisions `cargo-dylint` `6.0.1` and fixes this; its prebuilt dependency binaries are now published.

Changed files:
- [`.github/workflows/code_style.yml`](https://github.com/leynos/axinite/blob/bump-whitaker-installer-0.2.6/.github/workflows/code_style.yml)
